### PR TITLE
differentiate alpine bin

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,7 +65,7 @@ jobs:
             binary-name: rainfrog
             features: default
           - os: ubuntu-latest
-            os-name: linux
+            os-name: alpine
             target: i686-unknown-linux-musl 
             architecture: i686
             binary-postfix: ""


### PR DESCRIPTION
it was overwriting the other one with the same os name