### PR TITLE
feat: `docker run` option

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "MD033": {
+    "allowed_elements": ["details", "summary", "b"]
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /usr/src/app
 RUN useradd -m -s /bin/bash rainfrog
 
 # Copy the binary from the builder image
-COPY --chmod=755 --from=builder /app/target/release/rainfrog /usr/local/bin/rainfrog
+COPY --from=builder /app/target/release/rainfrog /usr/local/bin/rainfrog
 
 # Change ownership of the files to the non-root user
 RUN chown -R rainfrog:rainfrog /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM rust:alpine3.20 AS builder
+WORKDIR /app
+
+# Install system dependencies
+RUN apk add --no-cache musl-dev=1.2.5-r0
+
+# Build application
+COPY . .
+RUN cargo build --release
+
+# Create runtime image
+FROM debian:bookworm-slim AS runtime
+WORKDIR /usr/src/app
+
+# Create non-root user
+RUN useradd -m -s /bin/bash rainfrog
+
+# Copy the binary from the builder image
+COPY --chmod=755 --from=builder /app/target/release/rainfrog /usr/local/bin/rainfrog
+
+# Change ownership of the files to the non-root user
+RUN chown -R rainfrog:rainfrog /usr/src/app
+USER rainfrog
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD pidof rainfrog || exit 1
+
+# Command to construct the full connection URL using environment variables
+CMD ["bash", "-c", "rainfrog --url postgres://$username:$password@$hostname:$db_port/$dbname"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ a database management tui for postgres
 
 ![rainfrog demo](demo.gif)
 
-> [!WARNING] rainfrog is currently in beta.
+> [!WARNING]
+> rainfrog is currently in beta.
 
 the goal for rainfrog is to provide a lightweight, terminal-based alternative to
 pgadmin/dbeaver.
@@ -88,11 +89,30 @@ curl -LSsf https://raw.githubusercontent.com/achristmascarl/rainfrog/main/instal
 
 ## usage
 
-> [!NOTE] > `connection_url` must include your credentials for accessing the
-> database (ex. `postgres://username:password@localhost:5432/postgres`)
+> [!NOTE]
+> `connection_url` must include your credentials for accessing the database (ex. `postgres://username:password@localhost:5432/postgres`) 
 
 ```sh
 rainfrog --url $(connection_url)
+```
+
+### `docker run`
+
+> [!NOTE]
+> For now we build the image locally until the image is available in Docker Hub
+
+```sh
+docker build . -t rainfrog
+```
+
+```sh
+docker run -it --rm --name rainfrog \
+  -p <db_port>:<db_port> \
+  -e username="<username>" \
+  -e password="<password>" \
+  -e hostname="host.docker.internal" \
+  -e db_port="<db_port>" \
+  -e dbname="<dbname>" rainfrog
 ```
 
 ## keybindings
@@ -130,23 +150,37 @@ rainfrog --url $(connection_url)
 
 ### query editor
 
-keybindings may not behave exactly like vim. the full list of active vim
-keybindings in rainfrog can be found at [vim.rs](./src/vim.rs). | keybinding |
-description |
-|------------------------|----------------------------------------| |
-`Alt+Enter`, `F5` | execute query | | `j`, `↓` | move cursor down 1 line | |
-`k`, `↑` | move cursor up 1 line | | `h`, `←` | move cursor left 1 char | | `l`,
-`→` | move cursor right 1 char | | `w` | move cursor to next start of word | |
-`e` | move cursor to next end of word | | `b` | move cursor to prev start of
-word | | `0` | move cursor to beginning of line | | `$` | move cursor to end of
-line | | `gg` | jump to top of editor | | `G` | jump to bottom of current list |
-| `Esc` | return to normal mode | | `i` | enter insert (edit) mode | | `I` |
-enter insert mode at beginning of line | | `A` | enter insert mode at end of
-line | | `o` | insert new line below and insert | | `v` | enter visual (select)
-mode | | `V` | enter visual mode and select line | | `r` | begin replace
-operation | | `y` | begin yank (copy) operation | | `x` | begin cut operation |
-| `p` | paste from clipboard | | `u` | undo | | `Ctrl+r` | redo | | `Ctrl+e` |
-scroll down | | `Ctrl+y` | scroll up |
+Keybindings may not behave exactly like Vim. The full list of active Vim keybindings in Rainfrog can be found at [vim.rs](./src/vim.rs).
+
+| Keybinding                | Description                            |
+|---------------------------|----------------------------------------|
+| `Alt+Enter`, `F5`         | Execute query                          |
+| `j`, `↓`                  | Move cursor down 1 line                |
+| `k`, `↑`                  | Move cursor up 1 line                  |
+| `h`, `←`                  | Move cursor left 1 char                |
+| `l`, `→`                  | Move cursor right 1 char               |
+| `w`                       | Move cursor to next start of word      |
+| `e`                       | Move cursor to next end of word        |
+| `b`                       | Move cursor to previous start of word  |
+| `0`                       | Move cursor to beginning of line       |
+| `$`                       | Move cursor to end of line             |
+| `gg`                      | Jump to top of editor                  |
+| `G`                       | Jump to bottom of current list         |
+| `Esc`                     | Return to normal mode                  |
+| `i`                       | Enter insert (edit) mode               |
+| `I`                       | Enter insert mode at beginning of line | 
+| `A`                       | Enter insert mode at end of line       |
+| `o`                       | Insert new line below and enter insert |
+| `v`                       | Enter visual (select) mode             |
+| `V`                       | Enter visual mode and select line      |
+| `r`                       | Begin replace operation                |
+| `y`                       | Begin yank (copy) operation            |
+| `x`                       | Begin cut operation                    |
+| `p`                       | Paste from clipboard                   |
+| `u`                       | Undo                                   |
+| `Ctrl+r`                  | Redo                                   |
+| `Ctrl+e`                  | Scroll down                            |
+| `Ctrl+y`                  | Scroll up                              |
 
 ### query history
 

--- a/README.md
+++ b/README.md
@@ -1,207 +1,257 @@
 # 🐸 rainfrog
+
 a database management tui for postgres
 
 ![rainfrog demo](demo.gif)
 
-> [!WARNING]
-> rainfrog is currently in beta. 
+> [!WARNING] rainfrog is currently in beta.
 
-the goal for rainfrog is to provide a lightweight, terminal-based alternative to pgadmin/dbeaver. 
+the goal for rainfrog is to provide a lightweight, terminal-based alternative to
+pgadmin/dbeaver.
 
-### features
-- efficient navigation via vim-like keybindings and mouse controls 
+## features
+
+- efficient navigation via vim-like keybindings and mouse controls
 - query editor with keyword highlighting and session history
 - quickly copy data, filter tables, and switch between schemas
 - shortcuts to view table metadata and properties
 - cross-platform (macOS, linux, windows, android via termux)
 
 ### why "rainfrog"?
-> [frogs find refuge in elephant tracks](https://www.sciencedaily.com/releases/2019/06/190604131157.htm) 
+
+> [frogs find refuge in elephant tracks](https://www.sciencedaily.com/releases/2019/06/190604131157.htm)
 
 ## disclaimer
-this software is currently under active development; expect breaking changes, and use at your own risk. it is not recommended to use this tool with write access on a production database.
+
+this software is currently under active development; expect breaking changes,
+and use at your own risk. it is not recommended to use this tool with write
+access on a production database.
 
 ## installation
+
 ### cargo
-after installing rust (recommended to do so via [rustup](https://www.rust-lang.org/tools/install)):
+
+after installing rust (recommended to do so via
+[rustup](https://www.rust-lang.org/tools/install)):
+
 ```sh
 cargo install rainfrog
 ```
 
 ### arch linux
-arch linux users can install from the [official repositories](https://archlinux.org/packages/extra/x86_64/rainfrog) using [pacman](https://wiki.archlinux.org/title/pacman):
+
+arch linux users can install from the
+[official repositories](https://archlinux.org/packages/extra/x86_64/rainfrog)
+using [pacman](https://wiki.archlinux.org/title/pacman):
+
 ```sh
 pacman -S rainfrog
 ```
 
 ### termux
-if you are using [termux](https://termux.dev/), you'll need to install rust via their package manager:
+
+if you are using [termux](https://termux.dev/), you'll need to install rust via
+their package manager:
+
 ```sh
 pkg install rust
 ```
-and then make sure to install with termux features (and disable default features):
+
+and then make sure to install with termux features (and disable default
+features):
+
 ```sh
 cargo install rainfrog --features termux --no-default-features
 ```
 
 ### install script
-there is a simple install script that assists in downloading and unpacking a binary from the release page to `~/.local/bin/`, which you might want to add to your `PATH` variable if it isn't already there. you'll need to select which binary is appropriate for your system (if you're not sure, you can find out by installing rust and running `rustc -vV` to see the "host" target), and the script also needs [jq](https://github.com/jqlang/jq) and [fzf](https://github.com/junegunn/fzf) installed to run.
+
+there is a simple install script that assists in downloading and unpacking a
+binary from the release page to `~/.local/bin/`, which you might want to add to
+your `PATH` variable if it isn't already there. you'll need to select which
+binary is appropriate for your system (if you're not sure, you can find out by
+installing rust and running `rustc -vV` to see the "host" target), and the
+script also needs [jq](https://github.com/jqlang/jq) and
+[fzf](https://github.com/junegunn/fzf) installed to run.
+
 ```sh
 curl -LSsf https://raw.githubusercontent.com/achristmascarl/rainfrog/main/install.sh | bash
 ```
 
 ### release page binaries
-1. manually download and unpack the appropriate binary for your os from the latest [release](https://github.com/achristmascarl/rainfrog/releases) (if you're not sure which binary to pick, you can find out by installing rust and running `rustc -vV` to see the "host" target)
+
+1. manually download and unpack the appropriate binary for your os from the
+   latest [release](https://github.com/achristmascarl/rainfrog/releases) (if
+   you're not sure which binary to pick, you can find out by installing rust and
+   running `rustc -vV` to see the "host" target)
 2. move the binary to a folder in your `PATH` environment variable
 
 ## usage
-> [!NOTE]
-> `connection_url` must include your credentials for accessing the database (ex. `postgres://username:password@localhost:5432/postgres`) 
+
+> [!NOTE] > `connection_url` must include your credentials for accessing the
+> database (ex. `postgres://username:password@localhost:5432/postgres`)
+
 ```sh
 rainfrog --url $(connection_url)
 ```
 
 ## keybindings
+
 ### general
-| keybinding                  | description                            |
-|-----------------------------|----------------------------------------|
-| `Ctrl+c`                      | quit program                           |
-| `Alt+1`, `Ctrl+k`               | change focus to menu                   |
-| `Alt+2`, `Ctrl+j`               | change focus to query editor           |
-| `Alt+3`, `Ctrl+h`               | change focus to query history          |
-| `Alt+4`, `Ctrl+g`               | change focus to results                |
-| `Tab`                         | cycle focus forwards                   |
-| `Shift+Tab`                   | cycle focus backwards                  |
-| `q`, `Alt+q` in query editor    | abort current query                    |
+
+| keybinding                   | description                   |
+| ---------------------------- | ----------------------------- |
+| `Ctrl+c`                     | quit program                  |
+| `Alt+1`, `Ctrl+k`            | change focus to menu          |
+| `Alt+2`, `Ctrl+j`            | change focus to query editor  |
+| `Alt+3`, `Ctrl+h`            | change focus to query history |
+| `Alt+4`, `Ctrl+g`            | change focus to results       |
+| `Tab`                        | cycle focus forwards          |
+| `Shift+Tab`                  | cycle focus backwards         |
+| `q`, `Alt+q` in query editor | abort current query           |
 
 ### menu (list of schemas and tables)
-| keybinding                  | description                            |
-|-----------------------------|----------------------------------------|
-| `j`, `↓`                        | move selection down by 1               |
-| `k`, `↑`                        | move selection up by 1                 |
-| `g`                           | jump to top of current list            |
-| `G`                           | jump to bottom of current list         |
-| `h`, `←`                        | focus on schemas (if more than 1)      |
-| `l`, `→`                        | focus on tables                        |
-| `/`                           | filter tables                          |
-| `Esc`                         | clear search                           |
-| `Backspace`                   | focus on tables                        |
-| `Enter` when searching        | focus on tables                        |
-| `Enter` with selected schema  | focus on tables                        |
-| `Enter` with selected table   | preview table (100 rows)               |
-| `R`                           | reload schemas and tables              |
+
+| keybinding                   | description                       |
+| ---------------------------- | --------------------------------- |
+| `j`, `↓`                     | move selection down by 1          |
+| `k`, `↑`                     | move selection up by 1            |
+| `g`                          | jump to top of current list       |
+| `G`                          | jump to bottom of current list    |
+| `h`, `←`                     | focus on schemas (if more than 1) |
+| `l`, `→`                     | focus on tables                   |
+| `/`                          | filter tables                     |
+| `Esc`                        | clear search                      |
+| `Backspace`                  | focus on tables                   |
+| `Enter` when searching       | focus on tables                   |
+| `Enter` with selected schema | focus on tables                   |
+| `Enter` with selected table  | preview table (100 rows)          |
+| `R`                          | reload schemas and tables         |
 
 ### query editor
-keybindings may not behave exactly like vim. the full list of active vim keybindings in rainfrog can be found at [vim.rs](./src/vim.rs).
-| keybinding             | description                            |
-|------------------------|----------------------------------------|
-| `Alt+Enter`, `F5`          | execute query                          |
-| `j`, `↓`                   | move cursor down 1 line                |
-| `k`, `↑`                   | move cursor up 1 line                  |
-| `h`, `←`                   | move cursor left 1 char                |
-| `l`, `→`                   | move cursor right 1 char               |
-| `w`                      | move cursor to next start of word      |
-| `e`                      | move cursor to next end of word        |
-| `b`                      | move cursor to prev start of word      |
-| `0`                      | move cursor to beginning of line       |
-| `$`                      | move cursor to end of line             |
-| `gg`                     | jump to top of editor                  |
-| `G`                      | jump to bottom of current list         |
-| `Esc`                    | return to normal mode                  |
-| `i`                      | enter insert (edit) mode               |
-| `I`                      | enter insert mode at beginning of line | 
-| `A`                      | enter insert mode at end of line       |
-| `o`                      | insert new line below and insert       |
-| `v`                      | enter visual (select) mode             |
-| `V`                      | enter visual mode and select line      |
-| `r`                      | begin replace operation                |
-| `y`                      | begin yank (copy) operation            |
-| `x`                      | begin cut operation                    |
-| `p`                      | paste from clipboard                   |
-| `u`                      | undo                                   |
-| `Ctrl+r`                 | redo                                   |
-| `Ctrl+e`                 | scroll down                            |
-| `Ctrl+y`                 | scroll up                              |
 
-### query history 
-| keybinding                  | description                            |
-|-----------------------------|----------------------------------------|
-| `j`, `↓`                        | move selection down by 1               |
-| `k`, `↑`                        | move selection up by 1                 |
-| `g`                           | jump to top of list                    |
-| `G`                           | jump to bottom of list                 |
-| `y`                           | copy selected query                    |
-| `I`                           | edit selected query in editor          |
-| `D`                           | delete all history                     |
+keybindings may not behave exactly like vim. the full list of active vim
+keybindings in rainfrog can be found at [vim.rs](./src/vim.rs). | keybinding |
+description |
+|------------------------|----------------------------------------| |
+`Alt+Enter`, `F5` | execute query | | `j`, `↓` | move cursor down 1 line | |
+`k`, `↑` | move cursor up 1 line | | `h`, `←` | move cursor left 1 char | | `l`,
+`→` | move cursor right 1 char | | `w` | move cursor to next start of word | |
+`e` | move cursor to next end of word | | `b` | move cursor to prev start of
+word | | `0` | move cursor to beginning of line | | `$` | move cursor to end of
+line | | `gg` | jump to top of editor | | `G` | jump to bottom of current list |
+| `Esc` | return to normal mode | | `i` | enter insert (edit) mode | | `I` |
+enter insert mode at beginning of line | | `A` | enter insert mode at end of
+line | | `o` | insert new line below and insert | | `v` | enter visual (select)
+mode | | `V` | enter visual mode and select line | | `r` | begin replace
+operation | | `y` | begin yank (copy) operation | | `x` | begin cut operation |
+| `p` | paste from clipboard | | `u` | undo | | `Ctrl+r` | redo | | `Ctrl+e` |
+scroll down | | `Ctrl+y` | scroll up |
+
+### query history
+
+| keybinding | description                   |
+| ---------- | ----------------------------- |
+| `j`, `↓`   | move selection down by 1      |
+| `k`, `↑`   | move selection up by 1        |
+| `g`        | jump to top of list           |
+| `G`        | jump to bottom of list        |
+| `y`        | copy selected query           |
+| `I`        | edit selected query in editor |
+| `D`        | delete all history            |
 
 ### results
-| keybinding             | description                            |
-|------------------------|----------------------------------------|
-| `j`, `↓`                   | scroll down by 1 row                   |
-| `k`, `↑`                   | scroll up by 1 row                     |
-| `h`, `←`                   | scroll left by 1 cell                  |
-| `l`, `→`                   | scroll right by 1 cell                 |
-| `b`                      | scroll right by 1 cell                 |
-| `e`, `w`                   | scroll left by 1 column                |
-| `{`, `PageUp`, `Ctrl+b`      | jump up one page                       |
-| `}`, `PageDown`, `Ctrl+f`    | jump down one page                     |
-| `g`                      | jump to top of table                   |
-| `G`                      | jump to bottom of table                |
-| `0`                      | jump to first column                   |
-| `$`                      | jump to last column                    |
-| `v`                      | select individual field                |
-| `V`                      | select row                             |
-| `Enter`                  | change selection mode inwards          |
-| `Backspace`              | change selection mode outwards         |
-| `y`                      | copy selection                         |
-| `Esc`                    | stop selecting                         |
+
+| keybinding                | description                    |
+| ------------------------- | ------------------------------ |
+| `j`, `↓`                  | scroll down by 1 row           |
+| `k`, `↑`                  | scroll up by 1 row             |
+| `h`, `←`                  | scroll left by 1 cell          |
+| `l`, `→`                  | scroll right by 1 cell         |
+| `b`                       | scroll right by 1 cell         |
+| `e`, `w`                  | scroll left by 1 column        |
+| `{`, `PageUp`, `Ctrl+b`   | jump up one page               |
+| `}`, `PageDown`, `Ctrl+f` | jump down one page             |
+| `g`                       | jump to top of table           |
+| `G`                       | jump to bottom of table        |
+| `0`                       | jump to first column           |
+| `$`                       | jump to last column            |
+| `v`                       | select individual field        |
+| `V`                       | select row                     |
+| `Enter`                   | change selection mode inwards  |
+| `Backspace`               | change selection mode outwards |
+| `y`                       | copy selection                 |
+| `Esc`                     | stop selecting                 |
 
 ## roadmap
+
 <details>
   <summary><b>🏁 v0.1.0 – alpha</b></summary>
   
-  - [x] scrollable table 
-  - [x] cancellable async querying (spawn tokio task)
-  - [x] menu list with tables and schemas (collapsable)
-  - [x] tui-textarea for query editor
-  - [x] basic tui-textarea vim keybindings
-  - [x] handle custom types / enums
-  - [x] display rows affected
-  - [x] confirm before delete/drop
-  - [x] table selection and yanking
-  - [x] multi-line pasting
-  - [x] editor os clipboard support
-  - [x] handle mouse events
-  - [x] keybindings hints at bottom
-  - [x] branch protection
+- [x] scrollable table
+- [x] cancellable async querying (spawn tokio task)
+- [x] menu list with tables and schemas (collapsable)
+- [x] tui-textarea for query editor
+- [x] basic tui-textarea vim keybindings
+- [x] handle custom types / enums
+- [x] display rows affected
+- [x] confirm before delete/drop
+- [x] table selection and yanking
+- [x] multi-line pasting
+- [x] editor os clipboard support
+- [x] handle mouse events
+- [x] keybindings hints at bottom
+- [x] branch protection
+
 </details>
 
 <details>
   <summary><b>🏁 v0.2.0 – beta</b></summary>
 
-  - [x] vhs explainer gifs
-  - [x] upgrade ratatui and tui-textarea 
-  - [x] shortcuts to view indexes, keys, etc.
-  - [x] performant syntax highlighting
-  - [x] session history
-  - [x] changelog, release script
-  - [x] handle explain / analyze output
-  - [x] show query duration
-  - [x] install script for bins
+- [x] vhs explainer gifs
+- [x] upgrade ratatui and tui-textarea
+- [x] shortcuts to view indexes, keys, etc.
+- [x] performant syntax highlighting
+- [x] session history
+- [x] changelog, release script
+- [x] handle explain / analyze output
+- [x] show query duration
+- [x] install script for bins
+
 </details>
 
-now that rainfrog is in beta, check out the [issues tab](https://github.com/achristmascarl/rainfrog/issues) for planned features
+now that rainfrog is in beta, check out the
+[issues tab](https://github.com/achristmascarl/rainfrog/issues) for planned
+features
 
 ## known issues and limitations
-- in addition to the experience being subpar if the terminal window is too small, if the terminal window is too large, rainfrog will crash due to the maximum area of ratatui buffers being `u16::MAX` (65,535). more details in https://github.com/achristmascarl/rainfrog/issues/60
-- for query results with many columns, the height of the rendered `Table` widget may be limited due to the same limitation mentioned above. Could be fixed by https://github.com/ratatui-org/ratatui/issues/1250
-- on mac, for VS Code and terminal (and perhaps other editors), a setting for "use option as meta key" needs to be turned on for Alt/Opt keybindings to work. (In VS Code, it's `"terminal.integrated.macOptionIsMeta": true`; in kitty, it's `macos_option_as_alt yes` in the config.)
-- in visual mode, when selecting an entire line, the behavior is not the same as vim's, as it simply moves starts the selection at the head of the line, so moving up or down in lines will break the selection. 
-- mouse events are only used for changing focus and scrolling; the editor does not currently support mouse events, and menu items cannot be selected using the mouse
+
+- in addition to the experience being subpar if the terminal window is too
+  small, if the terminal window is too large, rainfrog will crash due to the
+  maximum area of ratatui buffers being `u16::MAX` (65,535). more details in
+  <https://github.com/achristmascarl/rainfrog/issues/60>
+- for query results with many columns, the height of the rendered `Table` widget
+  may be limited due to the same limitation mentioned above. Could be fixed by
+  <https://github.com/ratatui-org/ratatui/issues/1250>
+- on mac, for VS Code and terminal (and perhaps other editors), a setting for
+  "use option as meta key" needs to be turned on for Alt/Opt keybindings to
+  work. (In VS Code, it's `"terminal.integrated.macOptionIsMeta": true`; in
+  kitty, it's `macos_option_as_alt yes` in the config.)
+- in visual mode, when selecting an entire line, the behavior is not the same as
+  vim's, as it simply moves starts the selection at the head of the line, so
+  moving up or down in lines will break the selection.
+- mouse events are only used for changing focus and scrolling; the editor does
+  not currently support mouse events, and menu items cannot be selected using
+  the mouse
 
 ## acknowledgements
-- [ratatui](https://github.com/ratatui-org/ratatui) (this project used ratatui's [component template](https://github.com/ratatui-org/templates/tree/983aa3cb3b8dd743200e8e2a1faa6e7c06aad85e/component/template) as a starting point)
-- [tui-textarea](https://github.com/rhysd/tui-textarea) (used in the query editor)
-- [gobang](https://github.com/TaKO8Ki/gobang) (a rust db tui i drew inspiration from)
+
+- [ratatui](https://github.com/ratatui-org/ratatui) (this project used ratatui's
+  [component template](https://github.com/ratatui-org/templates/tree/983aa3cb3b8dd743200e8e2a1faa6e7c06aad85e/component/template)
+  as a starting point)
+- [tui-textarea](https://github.com/rhysd/tui-textarea) (used in the query
+  editor)
+- [gobang](https://github.com/TaKO8Ki/gobang) (a rust db tui i drew inspiration
+  from)
 - [ricky rainfrog](https://us.jellycat.com/ricky-rain-frog/)
 - [rainfroggg](https://www.rainfrog.gg/) (my wife's tattoo studio)


### PR DESCRIPTION
 This pr does the following:
- Adds Dockerfile to build the `rainfrog` binary
- Update readme
- resolves #89 

```shell
❯ docker run -it --rm --name rainfrog \
  -p 5432:5432 \
  -e username="rainfrog" \
  -e password="password" \
  -e hostname="host.docker.internal" \
  -e db_port="5432" \
  -e dbname="rainfrog" rainfrog
```
![image](https://github.com/user-attachments/assets/df407569-3a46-4ac7-a8e2-18e87bb36cc3)
