### PR TITLE
fix copy to the linux system clipboard

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -155,12 +155,14 @@ where
     let (action_tx, mut action_rx) = mpsc::unbounded_channel();
     let connection_opts = self.state.connection_opts.clone();
     let pool = database::init_pool::<DB>(connection_opts).await?;
-    let mut clipboard = Clipboard::new();
     log::info!("{pool:?}");
     self.pool = Some(pool);
 
     let mut tui = tui::Tui::new()?.mouse(self.mouse_mode_override.or(self.config.settings.mouse_mode));
     tui.enter()?;
+
+    #[allow(unused_mut)]
+    let mut clipboard = Clipboard::new();
 
     self.components.menu.register_action_handler(action_tx.clone())?;
     self.components.editor.register_action_handler(action_tx.clone())?;
@@ -460,13 +462,13 @@ where
                   log::error!("{e:?}");
                 },
                 |clipboard| {
-                  clipboard.set_text(data.clone()).unwrap_or_else(|e| {
+                  clipboard.set_text(data).unwrap_or_else(|e| {
                     log::error!("{e:?}");
                   })
                 },
               );
             }
-          }
+          },
           _ => {},
         }
         if !action_consumed {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Borrow, fmt::format, sync::Arc};
 
+#[cfg(not(feature = "termux"))]
 use arboard::Clipboard;
 use color_eyre::eyre::Result;
 use crossterm::event::{Event, KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
@@ -162,6 +163,7 @@ where
     tui.enter()?;
 
     #[allow(unused_mut)]
+    #[cfg(not(feature = "termux"))]
     let mut clipboard = Clipboard::new();
 
     self.components.menu.register_action_handler(action_tx.clone())?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -455,20 +455,17 @@ where
           Action::CopyData(data) => {
             #[cfg(not(feature = "termux"))]
             {
-              log::info!("Copy signal recieved, text is {}", data);
-              clipboard.as_mut().unwrap().set_text(data);
-              // Clipboard::new().map_or_else(
-              //   |e| {
-              //     log::error!("{e:?}");
-              //   },
-              //   |mut clipboard| {
-              //     clipboard.set_text(data.clone()).unwrap_or_else(|e| {
-              //       log::error!("{e:?}");
-              //     })
-              //   },
-              // );
+              clipboard.as_mut().map_or_else(
+                |e| {
+                  log::error!("{e:?}");
+                },
+                |clipboard| {
+                  clipboard.set_text(data.clone()).unwrap_or_else(|e| {
+                    log::error!("{e:?}");
+                  })
+                },
+              );
             }
-
           }
           _ => {},
         }

--- a/src/components/data.rs
+++ b/src/components/data.rs
@@ -70,7 +70,7 @@ pub struct Data<'a> {
   explain_max_y_offset: u16,
 }
 
-impl<'a> Data<'a> {
+impl Data<'_> {
   pub fn new() -> Self {
     Data {
       command_tx: None,
@@ -232,7 +232,7 @@ impl<'a> SettableDataTable<'a> for Data<'a> {
   }
 }
 
-impl<'a, DB: Database> Component<DB> for Data<'a> {
+impl<DB: Database> Component<DB> for Data<'_> {
   fn register_action_handler(&mut self, tx: UnboundedSender<Action>) -> Result<()> {
     self.command_tx = Some(tx);
     Ok(())

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -196,14 +196,7 @@ impl<'a, DB: Database + DatabaseQueries> Component<DB> for Editor<'a> {
         self.textarea.set_search_pattern(keyword_regex()).unwrap();
       },
       Action::CopyData(data) => {
-        #[cfg(not(feature = "termux"))]
-        {
-          self.textarea.set_yank_text(data);
-        }
-        #[cfg(feature = "termux")]
-        {
-          self.textarea.set_yank_text(data);
-        }
+        self.textarea.set_yank_text(data);
       },
       _ => {},
     }

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -195,6 +195,16 @@ impl<'a, DB: Database + DatabaseQueries> Component<DB> for Editor<'a> {
         self.textarea = TextArea::from(lines.clone());
         self.textarea.set_search_pattern(keyword_regex()).unwrap();
       },
+      Action::CopyData(data) => {
+        #[cfg(not(feature = "termux"))]
+        {
+          self.textarea.set_yank_text(data);
+        }
+        #[cfg(feature = "termux")]
+        {
+          self.textarea.set_yank_text(data);
+        }
+      },
       _ => {},
     }
     Ok(None)

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -52,7 +52,7 @@ pub struct Editor<'a> {
   last_query_duration: Option<chrono::Duration>,
 }
 
-impl<'a> Editor<'a> {
+impl Editor<'_> {
   pub fn new() -> Self {
     let mut textarea = TextArea::default();
     textarea.set_search_pattern(keyword_regex()).unwrap();
@@ -115,7 +115,7 @@ impl<'a> Editor<'a> {
   }
 }
 
-impl<'a, DB: Database + DatabaseQueries> Component<DB> for Editor<'a> {
+impl<DB: Database + DatabaseQueries> Component<DB> for Editor<'_> {
   fn register_action_handler(&mut self, tx: UnboundedSender<Action>) -> Result<()> {
     self.vim_state.register_action_handler(self.command_tx.clone())?;
     self.command_tx = Some(tx);

--- a/src/components/menu.rs
+++ b/src/components/menu.rs
@@ -159,7 +159,7 @@ impl Menu {
   }
 }
 
-impl<'a> SettableTableList<'a> for Menu {
+impl SettableTableList<'_> for Menu {
   fn set_table_list(&mut self, data: Option<Result<Rows, DbError>>) {
     log::info!("setting menu table list");
     self.table_map = IndexMap::new();

--- a/src/components/scroll_table.rs
+++ b/src/components/scroll_table.rs
@@ -191,7 +191,7 @@ impl<'a> ScrollTable<'a> {
   }
 }
 
-impl<'a, DB: Database> Component<DB> for ScrollTable<'a> {
+impl<DB: Database> Component<DB> for ScrollTable<'_> {
   fn draw(&mut self, f: &mut Frame<'_>, area: Rect, app_state: &AppState<'_, DB>) -> Result<()> {
     self.parent_area = area;
     let render_area = self.block.inner_if_some(area);
@@ -252,7 +252,7 @@ impl<'a> Renderer<'a> {
   }
 }
 
-impl<'a> Widget for Renderer<'a> {
+impl Widget for Renderer<'_> {
   fn render(self, area: Rect, buf: &mut Buffer) {
     let scrollable = self.0;
     let table = &scrollable.table;

--- a/src/vim.rs
+++ b/src/vim.rs
@@ -183,20 +183,7 @@ impl Vim {
               }
             }
             textarea.cut();
-            let text = textarea.yank_text();
-            #[cfg(not(feature = "termux"))]
-            {
-              Clipboard::new().map_or_else(
-                |e| {
-                  log::error!("{e:?}");
-                },
-                |mut clipboard| {
-                  clipboard.set_text(text).unwrap_or_else(|e| {
-                    log::error!("{e:?}");
-                  })
-                },
-              );
-            }
+            self.send_copy_action_with_text(textarea.yank_text());
             return Transition::Mode(Mode::Normal);
           },
           Input { key: Key::Char('i'), .. } => {

--- a/src/vim.rs
+++ b/src/vim.rs
@@ -1,7 +1,6 @@
 // vim emulation for tui_textarea. based on:
 // https://github.com/rhysd/tui-textarea/blob/main/examples/vim.rs
 use std::{env, fmt, fs, io, io::BufRead};
-use tokio::sync::mpsc::UnboundedSender;
 
 #[cfg(not(feature = "termux"))]
 use arboard::Clipboard;
@@ -17,6 +16,7 @@ use ratatui::{
   widgets::{Block, Borders},
   Terminal,
 };
+use tokio::sync::mpsc::UnboundedSender;
 use tui_textarea::{CursorMove, Input, Key, Scrolling, TextArea};
 
 use crate::action::Action;
@@ -364,9 +364,7 @@ impl Vim {
 
   fn send_copy_action_with_text(&self, text: String) {
     if let Some(sender) = &self.command_tx {
-      sender.send(Action::CopyData(text)).map_or_else(
-        |e| log::error!("{e:?}"), |_| {}
-      );
+      sender.send(Action::CopyData(text)).map_or_else(|e| log::error!("{e:?}"), |_| {});
     }
   }
 }

--- a/src/vim.rs
+++ b/src/vim.rs
@@ -1,6 +1,7 @@
 // vim emulation for tui_textarea. based on:
 // https://github.com/rhysd/tui-textarea/blob/main/examples/vim.rs
 use std::{env, fmt, fs, io, io::BufRead};
+use tokio::sync::mpsc::UnboundedSender;
 
 #[cfg(not(feature = "termux"))]
 use arboard::Clipboard;
@@ -17,6 +18,8 @@ use ratatui::{
   Terminal,
 };
 use tui_textarea::{CursorMove, Input, Key, Scrolling, TextArea};
+
+use crate::action::Action;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Mode {
@@ -93,15 +96,21 @@ pub enum Transition {
 pub struct Vim {
   pub mode: Mode,
   pub pending: Input, // Pending input to handle a sequence with two keys like gg
+  command_tx: Option<UnboundedSender<Action>>,
 }
 
 impl Vim {
   pub fn new(mode: Mode) -> Self {
-    Self { mode, pending: Input::default() }
+    Self { mode, pending: Input::default(), command_tx: None }
   }
 
   pub fn with_pending(self, pending: Input) -> Self {
-    Self { mode: self.mode, pending }
+    Self { mode: self.mode, pending, command_tx: None }
+  }
+
+  pub fn register_action_handler(&mut self, tx: Option<UnboundedSender<Action>>) -> Result<()> {
+    self.command_tx = tx;
+    Ok(())
   }
 
   pub fn transition(&self, input: Input, textarea: &mut TextArea<'_>) -> Transition {
@@ -288,20 +297,7 @@ impl Vim {
               }
             }
             textarea.copy();
-            let text = textarea.yank_text();
-            #[cfg(not(feature = "termux"))]
-            {
-              Clipboard::new().map_or_else(
-                |e| {
-                  log::error!("{e:?}");
-                },
-                |mut clipboard| {
-                  clipboard.set_text(text).unwrap_or_else(|e| {
-                    log::error!("{e:?}");
-                  })
-                },
-              );
-            }
+            self.send_copy_action_with_text(textarea.yank_text());
             return Transition::Mode(Mode::Normal);
           },
           Input { key: Key::Char('d'), ctrl: false, .. } if self.mode == Mode::Visual => {
@@ -328,20 +324,7 @@ impl Vim {
               }
             }
             textarea.cut();
-            let text = textarea.yank_text();
-            #[cfg(not(feature = "termux"))]
-            {
-              Clipboard::new().map_or_else(
-                |e| {
-                  log::error!("{e:?}");
-                },
-                |mut clipboard| {
-                  clipboard.set_text(text).unwrap_or_else(|e| {
-                    log::error!("{e:?}");
-                  })
-                },
-              );
-            }
+            self.send_copy_action_with_text(textarea.yank_text());
             return Transition::Mode(Mode::Insert);
           },
           Input { key: Key::Esc, .. } => {
@@ -355,20 +338,7 @@ impl Vim {
         match self.mode {
           Mode::Operator('y') => {
             textarea.copy();
-            let text = textarea.yank_text();
-            #[cfg(not(feature = "termux"))]
-            {
-              Clipboard::new().map_or_else(
-                |e| {
-                  log::error!("{e:?}");
-                },
-                |mut clipboard| {
-                  clipboard.set_text(text).unwrap_or_else(|e| {
-                    log::error!("{e:?}");
-                  })
-                },
-              );
-            }
+            self.send_copy_action_with_text(textarea.yank_text());
             Transition::Mode(Mode::Normal)
           },
           Mode::Operator('d') => {
@@ -377,20 +347,7 @@ impl Vim {
           },
           Mode::Operator('c') => {
             textarea.cut();
-            let text = textarea.yank_text();
-            #[cfg(not(feature = "termux"))]
-            {
-              Clipboard::new().map_or_else(
-                |e| {
-                  log::error!("{e:?}");
-                },
-                |mut clipboard| {
-                  clipboard.set_text(text).unwrap_or_else(|e| {
-                    log::error!("{e:?}");
-                  })
-                },
-              );
-            }
+            self.send_copy_action_with_text(textarea.yank_text());
             Transition::Mode(Mode::Insert)
           },
           _ => Transition::Nop,
@@ -415,6 +372,14 @@ impl Vim {
           },
         }
       },
+    }
+  }
+
+  fn send_copy_action_with_text(&self, text: String) {
+    if let Some(sender) = &self.command_tx {
+      sender.send(Action::CopyData(text)).map_or_else(
+        |e| log::error!("{e:?}"), |_| {}
+      );
     }
   }
 }


### PR DESCRIPTION
Hello! Thank you for your project, I liked it, but immediately I came across that the clipboard of the system was not working. I found the reason why this happens - the instance of **arboard clipboard** must run throughout [the lifetime of the entire program.](https://github.com/sigoden/aichat/issues/160#issuecomment-1783073536).
Instead of copying text, signals are sent in the vim module, which are processed in the app, as well as components.