### PR TITLE
bump to v0.2.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "rainfrog"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rainfrog"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 rust-version = "1.80"
 description = "a database management tui for postgres"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `rainfrog` version from `0.2.9` to `0.2.10`.
> 
>   - **Version Bump**:
>     - Update `rainfrog` version from `0.2.9` to `0.2.10` in `Cargo.toml` and `Cargo.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for 8e34b0109d8b27b58dad1f15c256b813c5047dec. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->