### PR TITLE
bump ratatui, tui-textarea

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ dependencies = [
  "strsim",
  "terminal_size",
  "unicase",
- "unicode-width",
+ "unicode-width 0.1.13",
 ]
 
 [[package]]
@@ -1336,6 +1336,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
 name = "instability"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2189,24 +2195,24 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
  "bitflags 2.6.0",
  "cassowary",
  "compact_str",
  "crossterm",
+ "indoc",
  "instability",
  "itertools",
  "lru",
  "paste",
  "serde",
  "strum",
- "strum_macros",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2683,9 +2689,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a875d8cd437cc8a97e9aeaeea352ec9a19aea99c23e9effb17757291de80b08"
+checksum = "05a528114c392209b3264855ad491fcce534b94a38771b0a0b97a79379275ce8"
 dependencies = [
  "log",
 ]
@@ -3290,14 +3296,14 @@ dependencies = [
 
 [[package]]
 name = "tui-textarea"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c07084342a575cea919eea996b9658a358c800b03d435df581c1d7c60e065a"
+checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
 dependencies = [
  "crossterm",
  "ratatui",
  "regex",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -3362,7 +3368,7 @@ checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.13",
 ]
 
 [[package]]
@@ -3370,6 +3376,12 @@ name = "unicode-width"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode_categories"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ lazy_static = "1.4.0"
 libc = "0.2.148"
 log = "0.4.20"
 pretty_assertions = "1.4.0"
-ratatui = { version = "0.28.0", features = [
+ratatui = { version = "0.29.0", features = [
   "serde",
   "macros",
   "unstable-widget-ref",
@@ -80,8 +80,8 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter", "serde"] }
 chrono = { version = "0.4", default-features = false }
 chrono-tz = { version = "0.10.0", default-features = false }
 indexmap = "2.2.6"
-tui-textarea = { version = "0.6.1", features = ["search"] }
-sqlparser = "0.52.0"
+tui-textarea = { version = "0.7.0", features = ["search"] }
+sqlparser = "0.53.0"
 arboard = { version = "3.4.1", optional = true, features = [
   "wayland-data-control",
 ] }

--- a/src/components/data.rs
+++ b/src/components/data.rs
@@ -209,7 +209,7 @@ impl<'a> SettableDataTable<'a> for Data<'a> {
             .header(header_row)
             .style(Style::default())
             .column_spacing(1)
-            .highlight_style(Style::default().fg(Color::LightBlue).reversed().bold());
+            .row_highlight_style(Style::default().fg(Color::LightBlue).reversed().bold());
           self.scrollable.set_table(buf_table, rows.headers.len(), rows.rows.len(), 36_u16);
           self.data_state = DataState::HasResults(rows);
         }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `ratatui`, `tui-textarea`, and `sqlparser` dependencies and rename a function call in `data.rs`.
> 
>   - **Dependencies**:
>     - Bump `ratatui` to `0.29.0` in `Cargo.toml` and `Cargo.lock`.
>     - Bump `tui-textarea` to `0.7.0` in `Cargo.toml` and `Cargo.lock`.
>     - Bump `sqlparser` to `0.53.0` in `Cargo.toml` and `Cargo.lock`.
>     - Add `indoc` dependency in `Cargo.lock`.
>     - Update `unicode-width` to `0.2.0` in `Cargo.lock`.
>   - **Code Changes**:
>     - Rename `highlight_style` to `row_highlight_style` in `Data::set_data_state()` in `data.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for dcf38b92a9daec20bf03f0465059e62c42f28322. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->