### PR TITLE
bump to v0.2.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "rainfrog"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rainfrog"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 rust-version = "1.80"
 description = "a database management tui for postgres"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `rainfrog` version from `0.2.10` to `0.2.11`.
> 
>   - **Version Bump**:
>     - Update `rainfrog` version from `0.2.10` to `0.2.11` in `Cargo.toml` and `Cargo.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for 980f2e7a4c0898a75e5c7449b8159ab203d78435. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->