### PR TITLE
prevents ci from running on merge for some reason

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,7 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-    - '**.md'
   pull_request:
-    paths-ignore:
-    - '**.md'
 
 jobs:
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes `paths-ignore` for markdown files in CI workflow, triggering CI on markdown changes.
> 
>   - **CI Trigger Changes**:
>     - Removed `paths-ignore` for `push` and `pull_request` events in `.github/workflows/ci.yml`.
>     - CI will now run on changes to markdown files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for c44e8f91d8e80efb406d778343561b42e52e1233. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->