### PR TITLE
propogate DATABASE_URL when present

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,7 @@ async fn tokio_main() -> Result<()> {
   } else {
     prompt_for_driver()?
   };
+  args.connection_url = url;
   match driver {
     Driver::Postgres => run_app::<Postgres>(args).await,
     Driver::Mysql => run_app::<MySql>(args).await,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Propagates `DATABASE_URL` to `args.connection_url` in `tokio_main()` if present and non-empty, logging a message when used.
> 
>   - **Behavior**:
>     - Propagates `DATABASE_URL` to `args.connection_url` in `tokio_main()` if present and non-empty.
>     - Logs a message when `DATABASE_URL` is used.
>   - **Functions**:
>     - Modifies `tokio_main()` in `main.rs` to set `args.connection_url` from `DATABASE_URL`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for a1e6878ea8bc109ddfccd4e04ba99009d0dc219a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->