### PR TITLE
include export dir in version string

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -163,8 +163,8 @@ macro_rules! trace_dbg {
 pub fn version() -> String {
   let author = clap::crate_authors!();
 
-  // let current_exe_path = PathBuf::from(clap::crate_name!()).display().to_string();
   let config_dir_path = get_config_dir().display().to_string();
+  let export_dir_path = get_export_dir().display().to_string();
   let data_dir_path = get_data_dir().display().to_string();
 
   format!(
@@ -174,6 +174,7 @@ pub fn version() -> String {
 Authors: {author}
 
 Config directory: {config_dir_path}
+Export directory: {export_dir_path}
 Data directory: {data_dir_path}"
   )
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `version()` in `utils.rs` now includes the export directory path in its output.
> 
>   - **Behavior**:
>     - `version()` in `utils.rs` now includes the export directory path in its output.
>   - **Misc**:
>     - Uncommented and utilized `get_export_dir()` in `version()` to retrieve the export directory path.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for 99adf34f6caf977f73ce5f66dba82f318d196d58. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->