### PR TITLE
fix install script compat with older jq versions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,8 +23,8 @@ main() {
   echo "temp dir: $temp"
 
   echo "installing 🐸 rainfrog..."
-  release_json=$(curl -s https://api.github.com/repos/achristmascarl/rainfrog/releases/latest | jq)
-  binary=$(jq <<<$release_json | jq -r '.["assets"] | .[] | .name' | sed -u "s/^.*[.sha256]$//" | sed -u "s/[.]tar[.]gz//" | awk 'NF' | fzf --header "choose a binary from the latest rainfrog release:" --reverse)
+  release_json=$(curl -s https://api.github.com/repos/achristmascarl/rainfrog/releases/latest | jq .)
+  binary=$(jq . <<<$release_json | jq -r '.["assets"] | .[] | .name' | sed -u "s/^.*[.sha256]$//" | sed -u "s/[.]tar[.]gz//" | awk 'NF' | fzf --header "choose a binary from the latest rainfrog release:" --reverse)
   if [ -z "$binary" ]; then
     echo "no binary selected"
     exit 1
@@ -36,8 +36,8 @@ main() {
 
   # download binary and hash
   echo "downloading binary and hash..."
-  curl -fL $(jq <<<$release_json | jq -r ".assets[] | select(.name | contains(\"$binary.tar.gz\")) | .browser_download_url") >"$temp/$binary.tar.gz"
-  curl -fL $(jq <<<$release_json | jq -r ".assets[] | select(.name | contains(\"$binary.sha256\")) | .browser_download_url") >"$temp/$binary.sha256"
+  curl -fL $(jq . <<<$release_json | jq -r ".assets[] | select(.name | contains(\"$binary.tar.gz\")) | .browser_download_url") >"$temp/$binary.tar.gz"
+  curl -fL $(jq . <<<$release_json | jq -r ".assets[] | select(.name | contains(\"$binary.sha256\")) | .browser_download_url") >"$temp/$binary.sha256"
   current=$(pwd)
   cd $temp
   shasum -c "$temp/$binary.sha256"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix compatibility with older `jq` versions in `install.sh` by adding a dot after `jq` commands.
> 
>   - **Compatibility**:
>     - Fix compatibility with older `jq` versions by adding a dot after `jq` commands in `install.sh`.
>   - **Behavior**:
>     - Ensures JSON parsing works correctly by explicitly specifying input for `jq` in `release_json` and `binary` variable assignments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for 947af6c48df1a99263ad603937b5ab924fc8131d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->