### PR TITLE
bump to v0.2.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "rainfrog"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rainfrog"
-version = "0.2.15"
+version = "0.2.16"
 edition = "2021"
 rust-version = "1.80"
 description = "a database management tui for postgres"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `rainfrog` version from `0.2.15` to `0.2.16`.
> 
>   - **Version Update**:
>     - Bump `rainfrog` version from `0.2.15` to `0.2.16` in `Cargo.toml` and `Cargo.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for d8278a87029f29beb617c6f5eef98c396a118bfb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->