### PR TITLE
remove branch deletion step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ release:
 	gh pr create --fill --label no-release-notes
 	gh pr diff | cat
 	@read -n 1 -p "are you sure you want to release v$(version)? [Y/n] " confirmation && if [ "$$confirmation" = "Y" ]; then echo " continuing..."; else echo " aborting..."; exit 1; fi
-	gh pr merge --admin --squash --delete-branch
+	gh pr merge --admin --squash
 	git checkout main
 	git pull
 	git tag "v$(version)" main


### PR DESCRIPTION
repo is set up to automatically delete merged branches already

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `--delete-branch` from `gh pr merge` in `Makefile` as repo auto-deletes merged branches.
> 
>   - **Makefile**:
>     - Remove `--delete-branch` from `gh pr merge` in `release` target.
>     - Repository auto-deletes merged branches, making this step unnecessary.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for 8ad56105bf7fd4b29ac7ff1b242187f835a5dcb0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->