### PR TITLE
refactor focus and popups

### DIFF
--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -194,6 +194,9 @@ impl<DB: Database + DatabaseQueries> Component<DB> for Editor<'_> {
         };
         self.textarea = TextArea::from(vec![query.clone()]);
         self.textarea.set_search_pattern(keyword_regex()).unwrap();
+        // make sure the editor tab is visible, then refocus the menu
+        self.command_tx.as_ref().unwrap().send(Action::FocusEditor)?;
+        self.command_tx.as_ref().unwrap().send(Action::FocusMenu)?;
         self.command_tx.as_ref().unwrap().send(Action::Query(vec![query.clone()], false))?;
       },
       Action::SubmitEditorQuery => {


### PR DESCRIPTION
- **refactor focus and popups**
- **autofocus editor on preview**

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactored focus and popup handling in `App` and `Editor` components, improving code maintainability and user experience.
> 
>   - **Focus and Popup Refactoring**:
>     - Introduced `set_focus()` and `set_popup()` methods in `App` to manage focus and popup state, replacing direct state manipulations.
>     - Removed redundant focus handling code by using `set_focus()` in `run()` and `draw_layout()` in `src/app.rs`.
>     - Consolidated focus cycling logic in `CycleFocusForwards` and `CycleFocusBackwards` actions using `set_focus()`.
>   - **Editor Component**:
>     - In `Editor`, ensured editor tab visibility before refocusing menu in `update()` method.
>     - Used `set_focus()` and `set_popup()` for focus management in `src/components/editor.rs`.
>   - **Miscellaneous**:
>     - Removed unused functions `last_focused_tab()` and `last_focused_component()` from `src/app.rs`.
>     - Improved code readability and maintainability by reducing code duplication.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for 93a4323d13dde21e879e11bcc9f2eed9f1cc99de. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->