### PR TITLE
percent encode password in constructed url string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2209,6 +2209,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "percent-encoding",
  "pretty_assertions",
  "ratatui",
  "rpassword",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ rpassword = "7.3.1"
 async-trait = "0.1.83"
 dotenvy = "0.15.7"
 csv = "1.3.1"
+percent-encoding = "2.3.1"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "android"))'.dependencies]
 keyring = { version = "3.6.2", features = [

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ use serde::{de::Deserializer, Deserialize};
 
 use crate::{action::Action, cli::Driver, focus::Focus, keyring::Password};
 
+// percent encoding for passwords in connection strings
 const FRAGMENT: &AsciiSet = &CONTROLS
   .add(b' ')
   .add(b'"')


### PR DESCRIPTION
closes #172 
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Percent-encode passwords in connection strings for PostgreSQL and MySQL drivers using the `percent-encoding` crate.
> 
>   - **Behavior**:
>     - Percent-encode passwords in `StructuredConnection::connection_string()` for `Postgres` and `MySql` drivers in `config.rs`.
>     - Uses `percent-encoding` crate to handle special characters in passwords.
>   - **Dependencies**:
>     - Add `percent-encoding` crate to `Cargo.toml` and `Cargo.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for 7785b452514f1a96ee7d9288d0dce0e0246dcef9. You can [customize](https://app.ellipsis.dev/achristmascarl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->