### PR TITLE
terminate query processes in postgres and mysql

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -389,14 +389,14 @@ impl App {
               },
               Ok((ExecutionType::Normal, _)) => {
                 self.components.data.set_loading();
-                database.start_query(query_string)?;
+                database.start_query(query_string).await?;
                 self.state.last_query_start = Some(chrono::Utc::now());
                 self.state.last_query_end = None;
               },
               Err(e) => self.components.data.set_data_state(Some(Err(e)), None),
             }
           },
-          Action::AbortQuery => match database.abort_query() {
+          Action::AbortQuery => match database.abort_query().await {
             Ok(true) => {
               self.components.data.set_cancelled();
               self.state.last_query_end = Some(chrono::Utc::now());
@@ -478,7 +478,7 @@ impl App {
         })?;
       }
       if self.should_quit {
-        database.abort_query()?;
+        database.abort_query().await?;
         tui.stop()?;
         break;
       }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -86,6 +86,9 @@ pub trait Database {
   async fn start_query(&mut self, query: String) -> Result<()>;
 
   /// Aborts the tokio task running the active query or transaction.
+  /// Some drivers also kill the process that was running the query,
+  /// so that the query does not continue running in the background.
+  /// This behavior needs to be implemented by the driver.
   async fn abort_query(&mut self) -> Result<bool>;
 
   /// Polls the tokio task for the active query or transaction if

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -83,10 +83,10 @@ pub trait Database {
 
   /// Spawns a tokio task that runs the query. The task should
   /// expect to be polled via the `get_query_results()` method.
-  fn start_query(&mut self, query: String) -> Result<()>;
+  async fn start_query(&mut self, query: String) -> Result<()>;
 
   /// Aborts the tokio task running the active query or transaction.
-  fn abort_query(&mut self) -> Result<bool>;
+  async fn abort_query(&mut self) -> Result<bool>;
 
   /// Polls the tokio task for the active query or transaction if
   /// it exists. Returns `DbTaskResult::NoTask` if no task is running,

--- a/src/database/mysql.rs
+++ b/src/database/mysql.rs
@@ -54,7 +54,7 @@ impl Database for MySqlDriver<'_> {
     let conn_for_task = conn.clone();
     let pid = sqlx::raw_sql("SELECT CONNECTION_ID()").fetch_one(conn.lock().await.as_mut()).await?.get::<u64, _>(0);
     log::info!("Starting query with PID {}", pid.clone());
-    self.querying_pid = Some(pid.to_string().clone());
+    self.querying_pid = Some(pid.to_string());
     self.task = Some(MySqlTask::Query(tokio::spawn(async move {
       let results = query_with_conn(conn_for_task.lock().await.as_mut(), first_query.clone()).await;
       match results {
@@ -145,7 +145,7 @@ impl Database for MySqlDriver<'_> {
     let mut tx = self.pool.as_mut().unwrap().begin().await?;
     let pid = sqlx::raw_sql("SELECT CONNECTION_ID()").fetch_one(&mut *tx).await?.get::<u64, _>(0);
     log::info!("Starting transaction with PID {}", pid.clone());
-    self.querying_pid = Some(pid.to_string().clone());
+    self.querying_pid = Some(pid.to_string());
     self.task = Some(MySqlTask::TxStart(tokio::spawn(async move {
       let (results, tx) = query_with_tx(tx, &first_query).await;
       match results {

--- a/src/database/mysql.rs
+++ b/src/database/mysql.rs
@@ -142,7 +142,7 @@ impl Database for MySqlDriver<'_> {
 
   async fn start_tx(&mut self, query: String) -> Result<()> {
     let (first_query, statement_type) = super::get_first_query(query, Driver::MySql)?;
-    let mut tx = self.pool.as_mut().unwrap().begin().await?;
+    let mut tx = self.pool.clone().unwrap().begin().await?;
     let pid = sqlx::raw_sql("SELECT CONNECTION_ID()").fetch_one(&mut *tx).await?.get::<u64, _>(0);
     log::info!("Starting transaction with PID {}", pid.clone());
     self.querying_pid = Some(pid.to_string());

--- a/src/database/mysql.rs
+++ b/src/database/mysql.rs
@@ -43,7 +43,7 @@ impl Database for MySqlDriver<'_> {
 
   // since it's possible for raw_sql to execute multiple queries in a single string,
   // we only execute the first one and then drop the rest.
-  fn start_query(&mut self, query: String) -> Result<()> {
+  async fn start_query(&mut self, query: String) -> Result<()> {
     let (first_query, statement_type) = super::get_first_query(query, Driver::MySql)?;
     let pool = self.pool.clone().unwrap();
     self.task = Some(MySqlTask::Query(tokio::spawn(async move {
@@ -61,7 +61,7 @@ impl Database for MySqlDriver<'_> {
     Ok(())
   }
 
-  fn abort_query(&mut self) -> Result<bool> {
+  async fn abort_query(&mut self) -> Result<bool> {
     match self.task.take() {
       Some(task) => {
         match task {

--- a/src/database/postgresql.rs
+++ b/src/database/postgresql.rs
@@ -149,7 +149,7 @@ impl Database for PostgresDriver<'_> {
 
   async fn start_tx(&mut self, query: String) -> Result<()> {
     let (first_query, statement_type) = super::get_first_query(query, Driver::Postgres)?;
-    let mut tx = self.pool.clone().unwrap().begin().await.unwrap();
+    let mut tx = self.pool.clone().unwrap().begin().await?;
     let pid = sqlx::raw_sql("SELECT pg_backend_pid()").fetch_one(&mut *tx).await?.get::<i32, _>(0);
     log::info!("Starting transaction with PID {}", pid.clone());
     self.querying_pid = Some(pid.to_string().clone());

--- a/src/database/postgresql.rs
+++ b/src/database/postgresql.rs
@@ -83,7 +83,7 @@ impl Database for PostgresDriver<'_> {
           _ => {},
         };
         if let Some(pid) = self.querying_pid.take() {
-          let success = sqlx::raw_sql(&format!("SELECT pg_cancel_backend('{pid}')"))
+          let success = sqlx::raw_sql(&format!("SELECT pg_cancel_backend({pid})"))
             .fetch_one(&*self.pool.clone().unwrap())
             .await?
             .get::<bool, _>(0);

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -43,7 +43,7 @@ impl Database for SqliteDriver<'_> {
 
   // since it's possible for raw_sql to execute multiple queries in a single string,
   // we only execute the first one and then drop the rest.
-  fn start_query(&mut self, query: String) -> Result<()> {
+  async fn start_query(&mut self, query: String) -> Result<()> {
     let (first_query, statement_type) = super::get_first_query(query, Driver::Sqlite)?;
     let pool = self.pool.clone().unwrap();
     self.task = Some(SqliteTask::Query(tokio::spawn(async move {
@@ -61,7 +61,7 @@ impl Database for SqliteDriver<'_> {
     Ok(())
   }
 
-  fn abort_query(&mut self) -> Result<bool> {
+  async fn abort_query(&mut self) -> Result<bool> {
     match self.task.take() {
       Some(task) => {
         match task {


### PR DESCRIPTION
closes #178 
- **use pg_cancel_backend when aborting queries**
- **fix postgres tx failed to start**
- **fix when tx doesnt start mysql sqlite**
- **process killing in mysql**

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add asynchronous query termination for PostgreSQL and MySQL, handling transaction start failures in MySQL and SQLite.
> 
>   - **Behavior**:
>     - `start_query` and `abort_query` methods in `database/mod.rs` are now asynchronous.
>     - PostgreSQL: Uses `pg_cancel_backend` to terminate queries in `postgresql.rs`.
>     - MySQL: Uses `KILL` command to terminate queries in `mysql.rs`.
>     - Handles transaction start failures in MySQL and SQLite.
>   - **Database Drivers**:
>     - Adds `querying_conn` and `querying_pid` to track active connections and PIDs in `MySqlDriver` and `PostgresDriver`.
>     - Updates `start_query` and `abort_query` to manage connection and PID lifecycle.
>   - **Misc**:
>     - Updates `app.rs` to call asynchronous `start_query` and `abort_query` methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for 3763f952379dd2accd8eac5e8863ca7d054dc6ad. You can [customize](https://app.ellipsis.dev/achristmascarl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->