### PR TITLE
Use the common default pattern for the password save prompt

### DIFF
--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -31,12 +31,12 @@ pub fn get_password(connection_name: &str, username: &str) -> Result<Password> {
         io::stdout().flush()?;
         io::stdin().read_line(&mut save)?;
         match save.trim() {
-          "Y" => {
+          "" | "Y" | "y" => {
             entry.set_password(&password)?;
             println!("Password saved in keyring");
             Ok(())
           },
-          "n" => {
+          "n" | "N" => {
             println!("Password not saved in keyring");
             Ok(())
           },


### PR DESCRIPTION
A common pattern in Unix is to make the capitalized letter the default, e.g., "Y/n" has "Y" as the default. Then the user just presses enter, and the default is selected. The current behavior fails if the user just presses enter; it is somewhat counterintuitive according to this convention.

[Reference](https://ux.stackexchange.com/questions/53640/default-values-for-text-based-confirmation-prompt)

- Added support for empty input and lowercase 'y'/'n' in the save prompt.
- Enhanced user experience by allowing more intuitive responses using defaults.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `get_password()` in `keyring.rs` to use a capitalized default option for the password save prompt, allowing empty input to select 'Y'.
> 
>   - **Behavior**:
>     - Modify `get_password()` in `keyring.rs` to accept empty input and lowercase 'y'/'n' for the save prompt.
>     - Default option is now 'Y', allowing users to press enter to save the password.
>   - **User Experience**:
>     - Aligns with Unix convention of capitalized default options in prompts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for b7845df600850732276037eea575ee30da96fcc2. You can [customize](https://app.ellipsis.dev/achristmascarl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->