### PR TITLE
fix clippy, collapse ifs

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -521,43 +521,45 @@ impl App {
       .constraints([Constraint::Length(1), Constraint::Fill(1)])
       .split(right_layout[0]);
 
-    if let Some(event) = &self.last_frame_mouse_event {
-      if self.popup.is_none() && event.kind != MouseEventKind::Moved && !matches!(event.kind, MouseEventKind::Down(_)) {
-        let position = Position::new(event.column, event.row);
-        let menu_target = root_layout[0];
-        let tabs_target = tabs_layout[0];
-        let tab_content_target = tabs_layout[1];
-        let data_target = right_layout[1];
-        if menu_target.contains(position) {
-          self.set_focus(Focus::Menu);
-        } else if data_target.contains(position) {
-          self.set_focus(Focus::Data);
-        } else if tab_content_target.contains(position) {
-          self.last_focused_tab();
-        } else if tabs_target.contains(position) {
-          match self.state.focus {
-            Focus::Editor => {
-              if matches!(event.kind, MouseEventKind::Up(_)) {
-                self.set_focus(Focus::History);
-              }
-            },
-            Focus::History => {
-              if matches!(event.kind, MouseEventKind::Up(_)) {
-                self.set_focus(Focus::Favorites);
-              }
-            },
-            Focus::Favorites => {
-              if matches!(event.kind, MouseEventKind::Up(_)) {
-                self.set_focus(Focus::Editor);
-              }
-            },
-            Focus::PopUp => {},
-            _ => {
-              self.state.focus = self.last_focused_tab;
-            },
-          }
-          self.last_frame_mouse_event = None;
+    if let Some(event) = &self.last_frame_mouse_event
+      && self.popup.is_none()
+      && event.kind != MouseEventKind::Moved
+      && !matches!(event.kind, MouseEventKind::Down(_))
+    {
+      let position = Position::new(event.column, event.row);
+      let menu_target = root_layout[0];
+      let tabs_target = tabs_layout[0];
+      let tab_content_target = tabs_layout[1];
+      let data_target = right_layout[1];
+      if menu_target.contains(position) {
+        self.set_focus(Focus::Menu);
+      } else if data_target.contains(position) {
+        self.set_focus(Focus::Data);
+      } else if tab_content_target.contains(position) {
+        self.last_focused_tab();
+      } else if tabs_target.contains(position) {
+        match self.state.focus {
+          Focus::Editor => {
+            if matches!(event.kind, MouseEventKind::Up(_)) {
+              self.set_focus(Focus::History);
+            }
+          },
+          Focus::History => {
+            if matches!(event.kind, MouseEventKind::Up(_)) {
+              self.set_focus(Focus::Favorites);
+            }
+          },
+          Focus::Favorites => {
+            if matches!(event.kind, MouseEventKind::Up(_)) {
+              self.set_focus(Focus::Editor);
+            }
+          },
+          Focus::PopUp => {},
+          _ => {
+            self.state.focus = self.last_focused_tab;
+          },
         }
+        self.last_frame_mouse_event = None;
       }
     }
     let tabs = Tabs::new(vec![" 󰤏 query <alt+2>", "   history <alt+4>", "   favorites <alt+5>"])

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -59,13 +59,13 @@ impl Editor<'_> {
   pub fn transition_vim_state(&mut self, input: Input, app_state: &AppState) -> Result<()> {
     match input {
       Input { key: Key::Enter, alt: true, .. } | Input { key: Key::Enter, ctrl: true, .. } => {
-        if !app_state.query_task_running {
-          if let Some(sender) = &self.command_tx {
-            sender.send(Action::Query(self.textarea.lines().to_vec(), false, false))?;
-            self.vim_state = Vim::new(Mode::Normal);
-            self.vim_state.register_action_handler(self.command_tx.clone())?;
-            self.cursor_style = Mode::Normal.cursor_style();
-          }
+        if !app_state.query_task_running
+          && let Some(sender) = &self.command_tx
+        {
+          sender.send(Action::Query(self.textarea.lines().to_vec(), false, false))?;
+          self.vim_state = Vim::new(Mode::Normal);
+          self.vim_state.register_action_handler(self.command_tx.clone())?;
+          self.cursor_style = Mode::Normal.cursor_style();
         }
       },
       Input { key: Key::Tab, shift: false, .. } if self.vim_state.mode != Mode::Insert => {

--- a/src/components/favorites.rs
+++ b/src/components/favorites.rs
@@ -204,10 +204,10 @@ impl Component for Favorites {
     match key.code {
       KeyCode::Enter if self.search_focused => {
         self.search_focused = false;
-        if let Some(search) = &self.search {
-          if search.is_empty() {
-            self.search = None;
-          }
+        if let Some(search) = &self.search
+          && search.is_empty()
+        {
+          self.search = None;
         }
         self.list_state = ListState::default().with_selected(Some(0));
       },

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -69,22 +69,22 @@ impl Tui {
   }
 
   pub fn tick_rate(mut self, tick_rate: Option<f64>) -> Self {
-    if tick_rate.is_some() {
-      self.tick_rate = tick_rate.unwrap()
+    if let Some(tick_rate) = tick_rate {
+      self.tick_rate = tick_rate;
     };
     self
   }
 
   pub fn frame_rate(mut self, frame_rate: Option<f64>) -> Self {
-    if frame_rate.is_some() {
-      self.frame_rate = frame_rate.unwrap();
+    if let Some(frame_rate) = frame_rate {
+      self.frame_rate = frame_rate;
     }
     self
   }
 
   pub fn mouse(mut self, mouse: Option<bool>) -> Self {
-    if mouse.is_some() {
-      self.mouse = mouse.unwrap();
+    if let Some(mouse) = mouse {
+      self.mouse = mouse;
     }
     self
   }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -41,10 +41,10 @@ pub fn initialize_panic_handler() -> Result<()> {
     .into_hooks();
   eyre_hook.install()?;
   std::panic::set_hook(Box::new(move |panic_info| {
-    if let Ok(mut t) = crate::tui::Tui::new() {
-      if let Err(r) = t.exit() {
-        error!("Unable to exit Terminal: {:?}", r);
-      }
+    if let Ok(mut t) = crate::tui::Tui::new()
+      && let Err(r) = t.exit()
+    {
+      error!("Unable to exit Terminal: {:?}", r);
     }
 
     #[cfg(not(debug_assertions))]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor code by collapsing nested `if` statements using `let`-`else` construct across multiple files to improve readability and maintainability.
> 
>   - **Refactoring**:
>     - Collapse nested `if` statements using `let`-`else` construct in `app.rs`, `editor.rs`, `favorites.rs`, `tui.rs`, and `utils.rs`.
>     - Improves code readability and maintainability without changing functionality.
>   - **Specific Changes**:
>     - In `app.rs`, refactor mouse event handling logic in `draw_layout()`.
>     - In `editor.rs`, refactor `transition_vim_state()` to use `let`-`else` for command transmission.
>     - In `favorites.rs`, refactor search handling logic in `handle_key_events()`.
>     - In `tui.rs`, refactor `tick_rate()`, `frame_rate()`, and `mouse()` methods.
>     - In `utils.rs`, refactor panic handler initialization in `initialize_panic_handler()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for 16c7cff701feb3409399a7dea98d25eec79e501c. You can [customize](https://app.ellipsis.dev/achristmascarl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->