### PR TITLE
fix: panic on none unwrap

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,0 @@
-export RAINFROG_CONFIG=`pwd`/.config
-export RAINFROG_DATA=`pwd`/.data
-export RAINFROG_LOG_LEVEL=debug

--- a/src/components/menu.rs
+++ b/src/components/menu.rs
@@ -236,29 +236,30 @@ impl Component for Menu {
             KeyCode::Char('R') => self.command_tx.as_ref().unwrap().send(Action::LoadMenu)?,
             KeyCode::Char('1') | KeyCode::Char('2') | KeyCode::Char('3') | KeyCode::Char('4') => {
               if let Some(selected) = self.list_state.selected() {
-                let (schema, tables) = self.table_map.get_index(self.schema_index).unwrap();
-                let filtered_tables: Vec<String> = tables
-                  .iter()
-                  .filter(|t| {
-                    if let Some(search) = self.search.as_ref() {
-                      t.to_lowercase().contains(search.to_lowercase().trim())
-                    } else {
-                      true
-                    }
-                  })
-                  .cloned()
-                  .collect();
-                self.command_tx.as_ref().unwrap().send(Action::MenuPreview(
-                  match key.code {
-                    KeyCode::Char('1') => MenuPreview::Columns,
-                    KeyCode::Char('2') => MenuPreview::Constraints,
-                    KeyCode::Char('3') => MenuPreview::Indexes,
-                    KeyCode::Char('4') => MenuPreview::Policies,
-                    _ => MenuPreview::Rows,
-                  },
-                  schema.clone(),
-                  filtered_tables[selected].clone(),
-                ))?;
+                if let Some((schema, tables)) = self.table_map.get_index(self.schema_index) {
+                  let filtered_tables: Vec<String> = tables
+                    .iter()
+                    .filter(|t| {
+                      if let Some(search) = self.search.as_ref() {
+                        t.to_lowercase().contains(search.to_lowercase().trim())
+                      } else {
+                        true
+                      }
+                    })
+                    .cloned()
+                    .collect();
+                  self.command_tx.as_ref().unwrap().send(Action::MenuPreview(
+                    match key.code {
+                      KeyCode::Char('1') => MenuPreview::Columns,
+                      KeyCode::Char('2') => MenuPreview::Constraints,
+                      KeyCode::Char('3') => MenuPreview::Indexes,
+                      KeyCode::Char('4') => MenuPreview::Policies,
+                      _ => MenuPreview::Rows,
+                    },
+                    schema.clone(),
+                    filtered_tables[selected].clone(),
+                  ))?;
+                }
               }
             },
             _ => {},

--- a/src/components/menu.rs
+++ b/src/components/menu.rs
@@ -235,31 +235,31 @@ impl Component for Menu {
             KeyCode::Char('G') => self.scroll_bottom(),
             KeyCode::Char('R') => self.command_tx.as_ref().unwrap().send(Action::LoadMenu)?,
             KeyCode::Char('1') | KeyCode::Char('2') | KeyCode::Char('3') | KeyCode::Char('4') => {
-              if let Some(selected) = self.list_state.selected() {
-                if let Some((schema, tables)) = self.table_map.get_index(self.schema_index) {
-                  let filtered_tables: Vec<String> = tables
-                    .iter()
-                    .filter(|t| {
-                      if let Some(search) = self.search.as_ref() {
-                        t.to_lowercase().contains(search.to_lowercase().trim())
-                      } else {
-                        true
-                      }
-                    })
-                    .cloned()
-                    .collect();
-                  self.command_tx.as_ref().unwrap().send(Action::MenuPreview(
-                    match key.code {
-                      KeyCode::Char('1') => MenuPreview::Columns,
-                      KeyCode::Char('2') => MenuPreview::Constraints,
-                      KeyCode::Char('3') => MenuPreview::Indexes,
-                      KeyCode::Char('4') => MenuPreview::Policies,
-                      _ => MenuPreview::Rows,
-                    },
-                    schema.clone(),
-                    filtered_tables[selected].clone(),
-                  ))?;
-                }
+              if let Some(selected) = self.list_state.selected()
+                && let Some((schema, tables)) = self.table_map.get_index(self.schema_index)
+              {
+                let filtered_tables: Vec<String> = tables
+                  .iter()
+                  .filter(|t| {
+                    if let Some(search) = self.search.as_ref() {
+                      t.to_lowercase().contains(search.to_lowercase().trim())
+                    } else {
+                      true
+                    }
+                  })
+                  .cloned()
+                  .collect();
+                self.command_tx.as_ref().unwrap().send(Action::MenuPreview(
+                  match key.code {
+                    KeyCode::Char('1') => MenuPreview::Columns,
+                    KeyCode::Char('2') => MenuPreview::Constraints,
+                    KeyCode::Char('3') => MenuPreview::Indexes,
+                    KeyCode::Char('4') => MenuPreview::Policies,
+                    _ => MenuPreview::Rows,
+                  },
+                  schema.clone(),
+                  filtered_tables[selected].clone(),
+                ))?;
               }
             },
             _ => {},


### PR DESCRIPTION
Fix issue #198 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes panic in `menu.rs` by checking for `None` before unwrapping `table_map.get_index(self.schema_index)` in `handle_key_events`.
> 
>   - **Behavior**:
>     - Fixes panic issue in `handle_key_events` in `menu.rs` by checking for `None` before unwrapping `table_map.get_index(self.schema_index)`.
>     - Returns `Ok(None)` if `schema_index` does not exist in `table_map`.
>   - **Misc**:
>     - Addresses issue #198.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for 295a2801ae46f381ea686345ca2752e1bd58a54c. You can [customize](https://app.ellipsis.dev/achristmascarl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->