### PR TITLE
fix ci docker test flakiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: init db for docker test
         run: |
           make db-up
-          sleep 5 # wait for db container
+          sleep 4 # wait for db container
       - name: docker run postgres
         run: |
           docker run -dit --name rainfrog_test_postgres \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: init db for docker test
         run: |
           make db-up
-          sleep 4 # wait for db container
+          sleep 10 # wait for db container
       - name: docker run postgres
         run: |
           docker run -dit --name rainfrog_test_postgres \


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Increase sleep duration in CI workflow to ensure database container readiness.
> 
>   - **CI Workflow**:
>     - Increase sleep duration from 5 to 10 seconds in `.github/workflows/ci.yml` to ensure the database container is ready before tests run.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for 114806eaa63f3217a86a048198484c6dc5e1c05c. You can [customize](https://app.ellipsis.dev/achristmascarl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->