### PR TITLE
optimize release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ opt-level = 2      # very slow on 1, basically as fast as --release on 2
 [profile.release]
 strip = "debuginfo"
 lto = "fat"
+codegen-units = 1
 
 [dependencies]
 better-panic = "0.3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![allow(unused_variables)]
 #![allow(async_fn_in_trait)]
+#![warn(unused_extern_crates)]
 
 pub mod action;
 pub mod app;


### PR DESCRIPTION
closes #207
- **codgen-units = 1 for release**
- **warn on unused deps**

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize release build by setting `codegen-units` to 1 and warn on unused external crates.
> 
>   - **Build Optimization**:
>     - Set `codegen-units = 1` in `[profile.release]` in `Cargo.toml` to optimize release build performance.
>   - **Compiler Warnings**:
>     - Add `#![warn(unused_extern_crates)]` in `main.rs` to warn on unused external crates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for 7ce359960aa0e09ee30d130fd29afc12ad367c52. You can [customize](https://app.ellipsis.dev/achristmascarl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->