### PR TITLE
cancel overlapping gh actions runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,11 @@ on:
       - main
   pull_request:
 
-jobs:
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
+jobs:
   test:
     name: Test Suite (${{ matrix.os-name }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add concurrency configuration to cancel in-progress GitHub Actions runs for the same pull request in `ci.yml`.
> 
>   - **Concurrency**:
>     - Adds `concurrency` configuration to `.github/workflows/ci.yml` to cancel in-progress runs for the same pull request using `group: ci-${{ github.event.pull_request.number || github.ref }}` and `cancel-in-progress: true`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for b3790d53d1f3c14d4f276fc308e5e6d72757e2d9. You can [customize](https://app.ellipsis.dev/achristmascarl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->