### PR TITLE
bump to v0.3.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2723,7 +2723,7 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rainfrog"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rainfrog"
-version = "0.3.8"
+version = "0.3.9"
 edition = "2024"
 rust-version = "1.88"
 description = "a database management tui"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `rainfrog` version from `0.3.8` to `0.3.9`.
> 
>   - **Version Bump**:
>     - Update `rainfrog` version from `0.3.8` to `0.3.9` in `Cargo.toml` and `Cargo.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for 83b8ad50df685accae1a007e7af8eff1b3703b64. You can [customize](https://app.ellipsis.dev/achristmascarl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->