### PR TITLE
bump sqlparser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3361,9 +3361,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4b661c54b1e4b603b37873a18c59920e4c51ea8ea2cf527d925424dbd4437c"
+checksum = "4591acadbcf52f0af60eafbb2c003232b2b4cd8de5f0e9437cb8b1b59046cc0f"
 dependencies = [
  "log",
  "recursive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ tracing-subscriber = { version = "0.3.20", features = ["env-filter", "serde"] }
 chrono = { version = "0.4", default-features = false }
 indexmap = "2.2.6"
 tui-textarea = { version = "0.7.0", features = ["search"] }
-sqlparser = "0.58.0"
+sqlparser = "0.59.0"
 arboard = { version = "3.4.1", optional = true, features = [
   "wayland-data-control",
 ] }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `sqlparser` version from `0.58.0` to `0.59.0` in `Cargo.toml` and `Cargo.lock`.
> 
>   - **Dependencies**:
>     - Bump `sqlparser` version from `0.58.0` to `0.59.0` in `Cargo.toml` and `Cargo.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for 9eb8e49b10b91f543661cb182a5c0bc46964a7b4. You can [customize](https://app.ellipsis.dev/achristmascarl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->