### PR TITLE
refocus last component after copying

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -469,7 +469,7 @@ impl App {
                 },
               );
             }
-            self.set_focus(Focus::Data);
+            self.last_focused_component();
           },
           Action::RequestExportData(row_count) => {
             self.set_popup(Box::new(ConfirmExport::new(*row_count)));


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change focus behavior after copying data to refocus the last component instead of defaulting to data view in `src/app.rs`.
> 
>   - **Behavior**:
>     - In `src/app.rs`, change focus behavior after `Action::CopyData` from `Focus::Data` to the last focused component using `last_focused_component()`.
>   - **Functions**:
>     - Modify `Action::CopyData` handling to call `last_focused_component()` instead of `set_focus(Focus::Data)` in `run()` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for 3263f76362f15338f14f10b6e30bea96c4c19116. You can [customize](https://app.ellipsis.dev/achristmascarl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->