### PR TITLE
fix history list selection

### DIFF
--- a/src/components/history.rs
+++ b/src/components/history.rs
@@ -168,7 +168,7 @@ impl Component for History {
       Some(x) if x > items.len().saturating_sub(1) => {
         self.list_state.select(Some(0));
       },
-      None if items.len() > 0 => {
+      None if !items.is_empty() => {
         self.list_state.select(Some(0));
       },
       _ => {},


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes list selection in `History` component to select the first item if no item is selected and the list is not empty.
> 
>   - **Behavior**:
>     - Fixes list selection in `History` component to select the first item if no item is selected and the list is not empty.
>     - Handles case where `list_state.selected()` is `None` and `items` is not empty in `draw()` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for 3cbd8ed31794c8f96d2e251707836a4022645974. You can [customize](https://app.ellipsis.dev/achristmascarl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->