### PR TITLE
bump to v0.3.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2723,7 +2723,7 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rainfrog"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rainfrog"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2024"
 rust-version = "1.88"
 description = "a database management tui"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `rainfrog` version from `0.3.12` to `0.3.13`.
> 
>   - **Version Bump**:
>     - Update `rainfrog` version from `0.3.12` to `0.3.13` in `Cargo.toml` and `Cargo.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for 1c6ff916a8f66d0e6ba0f3629695b7518dc93420. You can [customize](https://app.ellipsis.dev/achristmascarl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->