### PR TITLE
fix i686 release build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,7 +53,7 @@ jobs:
             binary-postfix: ""
             use-cross: true
             binary-name: rainfrog
-            features: --features default
+            features: --features arboard --no-default-features
           - os: ubuntu-latest
             target: i686-unknown-linux-musl
             binary-postfix: ""


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix build configuration for `i686` targets in `cd.yml` by adjusting features to `--features arboard --no-default-features`.
> 
>   - **Build Configuration**:
>     - In `.github/workflows/cd.yml`, change build features for `i686-unknown-linux-gnu` and `i686-unknown-linux-musl` targets to `--features arboard --no-default-features`.
>     - Ensures correct feature set is used for these targets, potentially fixing build issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=achristmascarl%2Frainfrog&utm_source=github&utm_medium=referral)<sup> for 734a938360e4994b3351e8982f0890a962d8ffb0. You can [customize](https://app.ellipsis.dev/achristmascarl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->