### PR TITLE
Fix execution type detection for CTE-wrapped writes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -206,13 +206,14 @@ impl App {
       }
       match database.get_query_results().await? {
         DbTaskResult::Finished(results) => {
-          self.components.data.set_data_state(Some(results.results), results.statement_type);
+          let statement_type = results.data_statement_type();
+          self.components.data.set_data_state(Some(results.results), statement_type);
           self.state.last_query_end = Some(chrono::Utc::now());
           self.state.query_task_running = false;
         },
-        DbTaskResult::ConfirmTx(rows_affected, statement) => {
+        DbTaskResult::ConfirmTx(rows_affected, statement, display_statement) => {
           self.state.last_query_end = Some(chrono::Utc::now());
-          self.set_popup(Box::new(ConfirmTx::new(rows_affected, statement)));
+          self.set_popup(Box::new(ConfirmTx::new(rows_affected, statement, display_statement)));
           self.state.query_task_running = true;
         },
         DbTaskResult::Pending => {
@@ -279,10 +280,8 @@ impl App {
                     let response = database.commit_tx().await?;
                     self.state.last_query_end = Some(chrono::Utc::now());
                     if let Some(results) = response {
-                      self
-                        .components
-                        .data
-                        .set_data_state(Some(results.results), results.statement_type);
+                      let statement_type = results.data_statement_type();
+                      self.components.data.set_data_state(Some(results.results), statement_type);
                       self.set_focus(Focus::Editor);
                     }
                   },

--- a/src/database/duckdb.rs
+++ b/src/database/duckdb.rs
@@ -45,12 +45,8 @@ impl Database for DuckDbDriver {
     self.task = Some(DuckDbTask::Query(tokio::spawn(async move {
       let results = run_query(connection, first_query).await;
       match results {
-        Ok(rows) => {
-          QueryResultsWithMetadata { results: Ok(rows), statement_type: Some(statement_type) }
-        },
-        Err(e) => {
-          QueryResultsWithMetadata { results: Err(e), statement_type: Some(statement_type) }
-        },
+        Ok(rows) => QueryResultsWithMetadata::new(Ok(rows), Some(statement_type)),
+        Err(e) => QueryResultsWithMetadata::new(Err(e), Some(statement_type)),
       }
     })));
     Ok(())

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -4,7 +4,7 @@ use color_eyre::eyre::Result;
 use sqlparser::dialect::DuckDbDialect;
 
 use sqlparser::{
-  ast::Statement,
+  ast::{Query, SetExpr, Statement},
   dialect::{Dialect, GenericDialect, MySqlDialect, PostgreSqlDialect, SQLiteDialect},
   keywords,
   parser::{Parser, ParserError},
@@ -168,53 +168,122 @@ pub fn get_execution_type(
   driver: Driver,
 ) -> Result<(ExecutionType, Option<Statement>)> {
   let (_, statement) = get_first_query(query, driver)?;
-  let default_execution_type = get_default_execution_type(statement.clone(), confirmed);
+  let default_execution_info = get_default_execution_info(&statement, confirmed);
 
   match driver {
     #[cfg(feature = "duckdb")]
-    Driver::DuckDb => match default_execution_type {
-      ExecutionType::Normal => Ok((ExecutionType::Normal, Some(statement))),
-      ExecutionType::Confirm => Ok((ExecutionType::Confirm, Some(statement))),
-      ExecutionType::Transaction => Ok((ExecutionType::Confirm, Some(statement))), // don't allow auto-transactions
+    Driver::DuckDb => match default_execution_info.execution_type {
+      ExecutionType::Normal => Ok((ExecutionType::Normal, Some(default_execution_info.statement))),
+      ExecutionType::Confirm => {
+        Ok((ExecutionType::Confirm, Some(default_execution_info.statement)))
+      },
+      ExecutionType::Transaction => {
+        Ok((ExecutionType::Confirm, Some(default_execution_info.statement)))
+      }, // don't allow auto-transactions
     },
-    _ => Ok((default_execution_type, Some(statement))),
+    _ => Ok((default_execution_info.execution_type, Some(default_execution_info.statement))),
   }
 }
 
-fn get_default_execution_type(statement: Statement, confirmed: bool) -> ExecutionType {
+#[derive(Debug)]
+struct ExecutionTypeInfo {
+  execution_type: ExecutionType,
+  statement: Statement,
+}
+
+fn get_default_execution_info(statement: &Statement, confirmed: bool) -> ExecutionTypeInfo {
   if confirmed {
-    return ExecutionType::Normal;
+    return ExecutionTypeInfo {
+      execution_type: ExecutionType::Normal,
+      statement: statement.clone(),
+    };
   }
+
+  get_statement_execution_type(statement)
+}
+
+fn get_statement_for_execution_type(statement: &Statement) -> Statement {
+  get_statement_execution_type(statement).statement
+}
+
+fn get_statement_execution_type(statement: &Statement) -> ExecutionTypeInfo {
   match statement {
     Statement::AlterIndex { .. }
     | Statement::AlterView { .. }
     | Statement::AlterRole { .. }
     | Statement::AlterTable { .. }
     | Statement::Drop { .. }
-    | Statement::Truncate { .. } => ExecutionType::Confirm,
-    Statement::Delete(_) | Statement::Update { .. } => ExecutionType::Transaction,
-    Statement::Explain { statement, analyze, .. }
-      if analyze
-        && matches!(
-          statement.as_ref(),
-          Statement::AlterIndex { .. }
-            | Statement::AlterView { .. }
-            | Statement::AlterRole { .. }
-            | Statement::AlterTable { .. }
-            | Statement::Drop { .. }
-            | Statement::Truncate { .. },
-        ) =>
-    {
-      ExecutionType::Confirm
+    | Statement::Truncate { .. } => {
+      ExecutionTypeInfo { execution_type: ExecutionType::Confirm, statement: statement.clone() }
     },
-    Statement::Explain { statement, analyze, .. }
-      if analyze
-        && matches!(statement.as_ref(), Statement::Delete(_) | Statement::Update { .. }) =>
-    {
-      ExecutionType::Transaction
+    Statement::Delete(_) | Statement::Update { .. } => {
+      ExecutionTypeInfo { execution_type: ExecutionType::Transaction, statement: statement.clone() }
     },
-    Statement::Explain { .. } => ExecutionType::Normal,
-    _ => ExecutionType::Normal,
+    Statement::Query(query) => get_query_execution_type(query).unwrap_or_else(|| {
+      ExecutionTypeInfo { execution_type: ExecutionType::Normal, statement: statement.clone() }
+    }),
+    Statement::Explain { statement: explained_statement, analyze, .. } if *analyze => {
+      let info = get_statement_execution_type(explained_statement);
+      if info.execution_type == ExecutionType::Normal {
+        ExecutionTypeInfo { execution_type: ExecutionType::Normal, statement: statement.clone() }
+      } else {
+        info
+      }
+    },
+    Statement::Explain { .. } => {
+      ExecutionTypeInfo { execution_type: ExecutionType::Normal, statement: statement.clone() }
+    },
+    _ => ExecutionTypeInfo { execution_type: ExecutionType::Normal, statement: statement.clone() },
+  }
+}
+
+fn get_query_execution_type(query: &Query) -> Option<ExecutionTypeInfo> {
+  let cte_execution_type = query
+    .with
+    .as_ref()
+    .map(|with| {
+      with
+        .cte_tables
+        .iter()
+        .map(|cte| get_query_execution_type(&cte.query))
+        .fold(None, max_execution_type)
+    })
+    .unwrap_or(None);
+
+  max_execution_type(cte_execution_type, get_set_expr_execution_type(&query.body))
+}
+
+fn get_set_expr_execution_type(set_expr: &SetExpr) -> Option<ExecutionTypeInfo> {
+  match set_expr {
+    SetExpr::Query(query) => get_query_execution_type(query),
+    SetExpr::SetOperation { left, right, .. } => {
+      max_execution_type(get_set_expr_execution_type(left), get_set_expr_execution_type(right))
+    },
+    SetExpr::Insert(statement)
+    | SetExpr::Update(statement)
+    | SetExpr::Delete(statement)
+    | SetExpr::Merge(statement) => Some(get_statement_execution_type(statement)),
+    _ => None,
+  }
+}
+
+fn max_execution_type(
+  left: Option<ExecutionTypeInfo>,
+  right: Option<ExecutionTypeInfo>,
+) -> Option<ExecutionTypeInfo> {
+  match (left, right) {
+    (Some(left), Some(right)) => Some(max_execution_type_info(left, right)),
+    (Some(left), None) => Some(left),
+    (None, Some(right)) => Some(right),
+    (None, None) => None,
+  }
+}
+
+fn max_execution_type_info(left: ExecutionTypeInfo, right: ExecutionTypeInfo) -> ExecutionTypeInfo {
+  match (&left.execution_type, &right.execution_type) {
+    (ExecutionType::Confirm, _) | (_, ExecutionType::Normal) => left,
+    (ExecutionType::Normal, _) | (_, ExecutionType::Confirm) => right,
+    (ExecutionType::Transaction, ExecutionType::Transaction) => left,
   }
 }
 
@@ -263,4 +332,87 @@ pub fn get_dialect(driver: Driver) -> Box<dyn Dialect + Send + Sync> {
 
 pub trait HasRowsAffected {
   fn rows_affected(&self) -> u64;
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn cte_wrapped_writes_use_write_execution_type() {
+    let test_cases = vec![
+      (
+        "WITH rows AS (SELECT id FROM users WHERE id = 1) \
+         UPDATE users SET name = 'Jane' WHERE id IN (SELECT id FROM rows)",
+        ExecutionType::Transaction,
+      ),
+      (
+        "WITH rows AS (SELECT id FROM users WHERE id = 1) \
+         DELETE FROM users WHERE id IN (SELECT id FROM rows)",
+        ExecutionType::Transaction,
+      ),
+      (
+        "WITH rows AS (SELECT id FROM users WHERE id = 1) SELECT * FROM rows",
+        ExecutionType::Normal,
+      ),
+    ];
+
+    for (query, expected) in test_cases {
+      let (execution_type, statement) =
+        get_execution_type(query.to_string(), false, Driver::Postgres).unwrap();
+
+      assert_eq!(execution_type, expected, "Failed for query: {query}");
+
+      match expected {
+        ExecutionType::Transaction => {
+          assert!(
+            matches!(statement, Some(Statement::Update { .. }) | Some(Statement::Delete(_))),
+            "Expected write statement for query: {query}, got {statement:?}"
+          );
+        },
+        ExecutionType::Normal => {
+          assert!(
+            matches!(statement, Some(Statement::Query(_))),
+            "Expected query statement for query: {query}, got {statement:?}"
+          );
+        },
+        ExecutionType::Confirm => {},
+      }
+    }
+  }
+
+  #[test]
+  fn writes_inside_ctes_use_write_execution_type() {
+    let query = "WITH deleted AS (DELETE FROM users WHERE id = 1 RETURNING id) \
+                 SELECT * FROM deleted";
+
+    let (execution_type, statement) =
+      get_execution_type(query.to_string(), false, Driver::Postgres).unwrap();
+
+    assert_eq!(execution_type, ExecutionType::Transaction);
+    assert!(matches!(statement, Some(Statement::Delete(_))));
+  }
+
+  #[test]
+  fn explain_analyze_cte_wrapped_writes_use_write_execution_type() {
+    let query = "EXPLAIN ANALYZE WITH rows AS (SELECT id FROM users WHERE id = 1) \
+                 UPDATE users SET name = 'Jane' WHERE id IN (SELECT id FROM rows)";
+
+    let (execution_type, statement) =
+      get_execution_type(query.to_string(), false, Driver::Postgres).unwrap();
+
+    assert_eq!(execution_type, ExecutionType::Transaction);
+    assert!(matches!(statement, Some(Statement::Update { .. })));
+  }
+
+  #[test]
+  fn explain_without_analyze_cte_wrapped_writes_are_normal() {
+    let query = "EXPLAIN WITH rows AS (SELECT id FROM users WHERE id = 1) \
+                 UPDATE users SET name = 'Jane' WHERE id IN (SELECT id FROM rows)";
+
+    assert_eq!(
+      get_execution_type(query.to_string(), false, Driver::Postgres).unwrap().0,
+      ExecutionType::Normal
+    );
+  }
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -51,6 +51,25 @@ pub struct Rows {
 pub struct QueryResultsWithMetadata {
   pub results: Result<Rows>,
   pub statement_type: Option<Statement>,
+  pub display_statement_type: Option<Statement>,
+}
+
+impl QueryResultsWithMetadata {
+  pub fn new(results: Result<Rows>, statement_type: Option<Statement>) -> Self {
+    Self { results, display_statement_type: statement_type.clone(), statement_type }
+  }
+
+  pub fn with_display_statement_type(
+    results: Result<Rows>,
+    statement_type: Option<Statement>,
+    display_statement_type: Option<Statement>,
+  ) -> Self {
+    Self { results, statement_type, display_statement_type }
+  }
+
+  pub fn data_statement_type(&self) -> Option<Statement> {
+    self.display_statement_type.clone().or_else(|| self.statement_type.clone())
+  }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -77,7 +96,7 @@ pub type QueryTask = JoinHandle<QueryResultsWithMetadata>;
 
 pub enum DbTaskResult {
   Finished(QueryResultsWithMetadata),
-  ConfirmTx(Option<u64>, Option<Statement>),
+  ConfirmTx(Option<u64>, Option<Statement>, Option<Statement>),
   Pending,
   NoTask,
 }
@@ -173,15 +192,24 @@ pub fn get_execution_type(
   match driver {
     #[cfg(feature = "duckdb")]
     Driver::DuckDb => match default_execution_info.execution_type {
-      ExecutionType::Normal => Ok((ExecutionType::Normal, Some(default_execution_info.statement))),
+      ExecutionType::Normal => {
+        Ok((ExecutionType::Normal, Some(default_execution_info.display_statement)))
+      },
       ExecutionType::Confirm => {
-        Ok((ExecutionType::Confirm, Some(default_execution_info.statement)))
+        Ok((ExecutionType::Confirm, Some(get_confirmation_statement(&default_execution_info))))
       },
       ExecutionType::Transaction => {
-        Ok((ExecutionType::Confirm, Some(default_execution_info.statement)))
+        Ok((ExecutionType::Confirm, Some(get_confirmation_statement(&default_execution_info))))
       }, // don't allow auto-transactions
     },
-    _ => Ok((default_execution_info.execution_type, Some(default_execution_info.statement))),
+    _ => {
+      let statement = match default_execution_info.execution_type {
+        ExecutionType::Normal => default_execution_info.display_statement,
+        ExecutionType::Confirm => get_confirmation_statement(&default_execution_info),
+        ExecutionType::Transaction => default_execution_info.statement,
+      };
+      Ok((default_execution_info.execution_type, Some(statement)))
+    },
   }
 }
 
@@ -189,6 +217,7 @@ pub fn get_execution_type(
 struct ExecutionTypeInfo {
   execution_type: ExecutionType,
   statement: Statement,
+  display_statement: Statement,
 }
 
 fn get_default_execution_info(statement: &Statement, confirmed: bool) -> ExecutionTypeInfo {
@@ -196,6 +225,7 @@ fn get_default_execution_info(statement: &Statement, confirmed: bool) -> Executi
     return ExecutionTypeInfo {
       execution_type: ExecutionType::Normal,
       statement: statement.clone(),
+      display_statement: statement.clone(),
     };
   }
 
@@ -204,6 +234,18 @@ fn get_default_execution_info(statement: &Statement, confirmed: bool) -> Executi
 
 fn get_statement_for_execution_type(statement: &Statement) -> Statement {
   get_statement_execution_type(statement).statement
+}
+
+fn get_display_statement_for_execution_type(statement: &Statement) -> Statement {
+  get_statement_execution_type(statement).display_statement
+}
+
+fn get_confirmation_statement(info: &ExecutionTypeInfo) -> Statement {
+  if matches!(info.display_statement, Statement::Explain { .. }) {
+    info.display_statement.clone()
+  } else {
+    info.statement.clone()
+  }
 }
 
 fn should_stream_tx_results(statement: &Statement) -> bool {
@@ -217,27 +259,45 @@ fn get_statement_execution_type(statement: &Statement) -> ExecutionTypeInfo {
     | Statement::AlterRole { .. }
     | Statement::AlterTable { .. }
     | Statement::Drop { .. }
-    | Statement::Truncate { .. } => {
-      ExecutionTypeInfo { execution_type: ExecutionType::Confirm, statement: statement.clone() }
+    | Statement::Truncate { .. } => ExecutionTypeInfo {
+      execution_type: ExecutionType::Confirm,
+      statement: statement.clone(),
+      display_statement: statement.clone(),
     },
-    Statement::Delete(_) | Statement::Update { .. } => {
-      ExecutionTypeInfo { execution_type: ExecutionType::Transaction, statement: statement.clone() }
+    Statement::Delete(_) | Statement::Update { .. } => ExecutionTypeInfo {
+      execution_type: ExecutionType::Transaction,
+      statement: statement.clone(),
+      display_statement: statement.clone(),
     },
-    Statement::Query(query) => get_query_execution_type(query).unwrap_or_else(|| {
-      ExecutionTypeInfo { execution_type: ExecutionType::Normal, statement: statement.clone() }
-    }),
+    Statement::Query(query) => match get_query_execution_type(query) {
+      Some(mut info) => {
+        info.display_statement = statement.clone();
+        info
+      },
+      None => ExecutionTypeInfo {
+        execution_type: ExecutionType::Normal,
+        statement: statement.clone(),
+        display_statement: statement.clone(),
+      },
+    },
     Statement::Explain { statement: explained_statement, analyze, .. } if *analyze => {
       let info = get_statement_execution_type(explained_statement);
-      if info.execution_type == ExecutionType::Normal {
-        ExecutionTypeInfo { execution_type: ExecutionType::Normal, statement: statement.clone() }
-      } else {
-        info
+      ExecutionTypeInfo {
+        execution_type: info.execution_type,
+        statement: info.statement,
+        display_statement: statement.clone(),
       }
     },
-    Statement::Explain { .. } => {
-      ExecutionTypeInfo { execution_type: ExecutionType::Normal, statement: statement.clone() }
+    Statement::Explain { .. } => ExecutionTypeInfo {
+      execution_type: ExecutionType::Normal,
+      statement: statement.clone(),
+      display_statement: statement.clone(),
     },
-    _ => ExecutionTypeInfo { execution_type: ExecutionType::Normal, statement: statement.clone() },
+    _ => ExecutionTypeInfo {
+      execution_type: ExecutionType::Normal,
+      statement: statement.clone(),
+      display_statement: statement.clone(),
+    },
   }
 }
 
@@ -420,9 +480,30 @@ mod tests {
 
     let (execution_type, statement) =
       get_execution_type(query.to_string(), false, Driver::Postgres).unwrap();
+    let (_, root_statement) = get_first_query(query.to_string(), Driver::Postgres).unwrap();
 
     assert_eq!(execution_type, ExecutionType::Transaction);
     assert!(matches!(statement, Some(Statement::Update { .. })));
+    assert!(matches!(
+      get_display_statement_for_execution_type(&root_statement),
+      Statement::Explain { statement, .. } if matches!(*statement, Statement::Query(_))
+    ));
+  }
+
+  #[test]
+  fn explain_analyze_writes_preserve_explain_display_statement() {
+    let query = "EXPLAIN ANALYZE UPDATE users SET name = 'Jane' WHERE id = 1";
+
+    let (execution_type, statement) =
+      get_execution_type(query.to_string(), false, Driver::Postgres).unwrap();
+    let (_, root_statement) = get_first_query(query.to_string(), Driver::Postgres).unwrap();
+
+    assert_eq!(execution_type, ExecutionType::Transaction);
+    assert!(matches!(statement, Some(Statement::Update { .. })));
+    assert!(matches!(
+      get_display_statement_for_execution_type(&root_statement),
+      Statement::Explain { statement, .. } if matches!(*statement, Statement::Update { .. })
+    ));
   }
 
   #[test]

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -206,6 +206,10 @@ fn get_statement_for_execution_type(statement: &Statement) -> Statement {
   get_statement_execution_type(statement).statement
 }
 
+fn should_stream_tx_results(statement: &Statement) -> bool {
+  matches!(statement, Statement::Explain { .. } | Statement::Query(_))
+}
+
 fn get_statement_execution_type(statement: &Statement) -> ExecutionTypeInfo {
   match statement {
     Statement::AlterIndex { .. }
@@ -385,12 +389,28 @@ mod tests {
   fn writes_inside_ctes_use_write_execution_type() {
     let query = "WITH deleted AS (DELETE FROM users WHERE id = 1 RETURNING id) \
                  SELECT * FROM deleted";
+    let (_, root_statement) = get_first_query(query.to_string(), Driver::Postgres).unwrap();
 
     let (execution_type, statement) =
       get_execution_type(query.to_string(), false, Driver::Postgres).unwrap();
 
+    assert!(matches!(root_statement, Statement::Query(_)));
+    assert!(should_stream_tx_results(&root_statement));
     assert_eq!(execution_type, ExecutionType::Transaction);
     assert!(matches!(statement, Some(Statement::Delete(_))));
+  }
+
+  #[test]
+  fn tx_streaming_uses_root_statement_not_representative_statement() {
+    let query = "WITH deleted AS (DELETE FROM users WHERE id = 1 RETURNING id) \
+                 SELECT * FROM deleted";
+    let (_, root_statement) = get_first_query(query.to_string(), Driver::Postgres).unwrap();
+    let representative_statement = get_statement_for_execution_type(&root_statement);
+
+    assert!(matches!(root_statement, Statement::Query(_)));
+    assert!(matches!(representative_statement, Statement::Delete(_)));
+    assert!(should_stream_tx_results(&root_statement));
+    assert!(!should_stream_tx_results(&representative_statement));
   }
 
   #[test]

--- a/src/database/mysql.rs
+++ b/src/database/mysql.rs
@@ -106,7 +106,7 @@ impl Database for MySqlDriver<'_> {
           log::error!("{e:?}");
         },
       };
-      QueryResultsWithMetadata { results, statement_type: statement_type.clone() }
+      QueryResultsWithMetadata::new(results, statement_type.clone())
     })));
     Ok(())
   }
@@ -163,20 +163,29 @@ impl Database for MySqlDriver<'_> {
           };
           match result {
             // if tx failed to start, return the error immediately
-            QueryResultsWithMetadata { results: Err(e), statement_type } => {
+            QueryResultsWithMetadata {
+              results: Err(e),
+              statement_type,
+              display_statement_type,
+            } => {
               log::error!("Transaction didn't start: {e:?}");
               self.querying_conn = None;
               self.querying_pid = None;
               (
-                DbTaskResult::Finished(QueryResultsWithMetadata {
-                  results: Err(e),
+                DbTaskResult::Finished(QueryResultsWithMetadata::with_display_statement_type(
+                  Err(e),
                   statement_type,
-                }),
+                  display_statement_type,
+                )),
                 None,
               )
             },
             _ => (
-              DbTaskResult::ConfirmTx(rows_affected, result.statement_type.clone()),
+              DbTaskResult::ConfirmTx(
+                rows_affected,
+                result.statement_type.clone(),
+                result.display_statement_type.clone(),
+              ),
               Some(MySqlTask::TxPending(Box::new((tx, result)))),
             ),
           }
@@ -190,6 +199,7 @@ impl Database for MySqlDriver<'_> {
 
   async fn start_tx(&mut self, query: String) -> Result<()> {
     let (first_query, statement_type) = super::get_first_query(query, Driver::MySql)?;
+    let display_statement_type = super::get_display_statement_for_execution_type(&statement_type);
     let statement_type = super::get_statement_for_execution_type(&statement_type);
     let mut tx = self.pool.clone().unwrap().begin().await?;
     let pid = sqlx::raw_sql("SELECT CONNECTION_ID()").fetch_one(&mut *tx).await?.get::<u64, _>(0);
@@ -208,17 +218,32 @@ impl Database for MySqlDriver<'_> {
                 rows_affected: Some(rows_affected),
               }),
               statement_type: Some(statement_type),
+              display_statement_type: Some(display_statement_type),
             },
             tx,
           )
         },
         Ok(Either::Right(rows)) => {
           log::info!("{:?} rows affected", rows.rows_affected);
-          (QueryResultsWithMetadata { results: Ok(rows), statement_type: Some(statement_type) }, tx)
+          (
+            QueryResultsWithMetadata::with_display_statement_type(
+              Ok(rows),
+              Some(statement_type),
+              Some(display_statement_type),
+            ),
+            tx,
+          )
         },
         Err(e) => {
           log::error!("{e:?}");
-          (QueryResultsWithMetadata { results: Err(e), statement_type: Some(statement_type) }, tx)
+          (
+            QueryResultsWithMetadata::with_display_statement_type(
+              Err(e),
+              Some(statement_type),
+              Some(display_statement_type),
+            ),
+            tx,
+          )
         },
       }
     })));

--- a/src/database/mysql.rs
+++ b/src/database/mysql.rs
@@ -191,6 +191,7 @@ impl Database for MySqlDriver<'_> {
 
   async fn start_tx(&mut self, query: String) -> Result<()> {
     let (first_query, statement_type) = super::get_first_query(query, Driver::MySql)?;
+    let statement_type = super::get_statement_for_execution_type(&statement_type);
     let mut tx = self.pool.clone().unwrap().begin().await?;
     let pid = sqlx::raw_sql("SELECT CONNECTION_ID()").fetch_one(&mut *tx).await?.get::<u64, _>(0);
     log::info!("Starting transaction with PID {}", pid.clone());

--- a/src/database/mysql.rs
+++ b/src/database/mysql.rs
@@ -9,7 +9,6 @@ use std::{
 use async_trait::async_trait;
 use color_eyre::eyre::{self, Result};
 use futures::stream::StreamExt;
-use sqlparser::ast::Statement;
 use sqlx::{
   Column, Either, MySqlConnection, Row, ValueRef,
   mysql::{MySql, MySqlConnectOptions, MySqlPoolOptions},
@@ -468,7 +467,7 @@ where
   let first_query = super::get_first_query(query.to_string(), Driver::MySql);
   match first_query {
     Ok((first_query, statement_type)) => match statement_type {
-      Statement::Explain { .. } => {
+      statement_type if super::should_stream_tx_results(&statement_type) => {
         let result = query_with_stream(&mut *tx, &first_query).await;
         match result {
           Ok(result) => (Ok(Either::Right(result)), tx),

--- a/src/database/oracle/mod.rs
+++ b/src/database/oracle/mod.rs
@@ -51,12 +51,18 @@ impl Database for OracleDriver {
   }
 
   async fn start_query(&mut self, query: String, bypass_parser: bool) -> Result<()> {
-    let (first_query, statement_type, routing_statement_type) = if bypass_parser {
-      (query, None, None)
-    } else {
-      let (first, stmt) = super::get_first_query(query, Driver::Oracle)?;
-      (first, Some(super::get_statement_for_execution_type(&stmt)), Some(stmt))
-    };
+    let (first_query, statement_type, display_statement_type, routing_statement_type) =
+      if bypass_parser {
+        (query, None, None, None)
+      } else {
+        let (first, stmt) = super::get_first_query(query, Driver::Oracle)?;
+        (
+          first,
+          Some(super::get_statement_for_execution_type(&stmt)),
+          Some(super::get_display_statement_for_execution_type(&stmt)),
+          Some(stmt),
+        )
+      };
     let pool = self.pool.clone().unwrap();
 
     let conn = Arc::new(pool.get()?);
@@ -65,7 +71,11 @@ impl Database for OracleDriver {
     let task = match routing_statement_type {
       Some(Statement::Query(_)) => OracleTask::Query(tokio::spawn(async move {
         let results = query_with_conn(query_conn.as_ref(), &first_query);
-        QueryResultsWithMetadata { results, statement_type }
+        QueryResultsWithMetadata::with_display_statement_type(
+          results,
+          statement_type,
+          display_statement_type,
+        )
       })),
       _ => OracleTask::TxStart(tokio::spawn(async move {
         let results = execute_with_conn(query_conn.as_ref(), &first_query);
@@ -77,7 +87,11 @@ impl Database for OracleDriver {
             log::error!("{e:?}");
           },
         };
-        Ok(QueryResultsWithMetadata { results, statement_type })
+        Ok(QueryResultsWithMetadata::with_display_statement_type(
+          results,
+          statement_type,
+          display_statement_type,
+        ))
       })),
     };
 
@@ -126,19 +140,28 @@ impl Database for OracleDriver {
           };
           match result {
             // if tx failed to start, return the error immediately
-            QueryResultsWithMetadata { results: Err(e), statement_type } => {
+            QueryResultsWithMetadata {
+              results: Err(e),
+              statement_type,
+              display_statement_type,
+            } => {
               log::error!("Transaction didn't start: {e:?}");
               self.querying_conn = None;
               (
-                DbTaskResult::Finished(QueryResultsWithMetadata {
-                  results: Err(e),
+                DbTaskResult::Finished(QueryResultsWithMetadata::with_display_statement_type(
+                  Err(e),
                   statement_type,
-                }),
+                  display_statement_type,
+                )),
                 None,
               )
             },
             _ => (
-              DbTaskResult::ConfirmTx(rows_affected, result.statement_type.clone()),
+              DbTaskResult::ConfirmTx(
+                rows_affected,
+                result.statement_type.clone(),
+                result.display_statement_type.clone(),
+              ),
               Some(OracleTask::TxPending(Box::new(result))),
             ),
           }

--- a/src/database/oracle/mod.rs
+++ b/src/database/oracle/mod.rs
@@ -174,7 +174,11 @@ impl Database for OracleDriver {
     let query_conn = conn.clone();
     self.querying_conn = Some(conn);
     self.task = Some(OracleTask::TxStart(tokio::spawn(async move {
-      let results = execute_with_conn(query_conn.as_ref(), &first_query);
+      let results = if super::should_stream_tx_results(&stmt) {
+        query_with_conn(query_conn.as_ref(), &first_query)
+      } else {
+        execute_with_conn(query_conn.as_ref(), &first_query)
+      };
       match results {
         Ok(ref rows) => {
           log::info!("{:?} rows, {:?} affected", rows.rows.len(), rows.rows_affected);

--- a/src/database/oracle/mod.rs
+++ b/src/database/oracle/mod.rs
@@ -51,51 +51,35 @@ impl Database for OracleDriver {
   }
 
   async fn start_query(&mut self, query: String, bypass_parser: bool) -> Result<()> {
-    let (first_query, statement_type, display_statement_type, routing_statement_type) =
-      if bypass_parser {
-        (query, None, None, None)
-      } else {
-        let (first, stmt) = super::get_first_query(query, Driver::Oracle)?;
-        (
-          first,
-          Some(super::get_statement_for_execution_type(&stmt)),
-          Some(super::get_display_statement_for_execution_type(&stmt)),
-          Some(stmt),
-        )
-      };
+    let (first_query, statement_type, display_statement_type, use_query_api) = if bypass_parser {
+      (query, None, None, false)
+    } else {
+      let (first, stmt) = super::get_first_query(query, Driver::Oracle)?;
+      let use_query_api = matches!(stmt, Statement::Query(_));
+      (
+        first,
+        Some(super::get_statement_for_execution_type(&stmt)),
+        Some(super::get_display_statement_for_execution_type(&stmt)),
+        use_query_api,
+      )
+    };
     let pool = self.pool.clone().unwrap();
 
     let conn = Arc::new(pool.get()?);
     let query_conn = conn.clone();
     self.querying_conn = Some(conn);
-    let task = match routing_statement_type {
-      Some(Statement::Query(_)) => OracleTask::Query(tokio::spawn(async move {
-        let results = query_with_conn(query_conn.as_ref(), &first_query);
-        QueryResultsWithMetadata::with_display_statement_type(
-          results,
-          statement_type,
-          display_statement_type,
-        )
-      })),
-      _ => OracleTask::TxStart(tokio::spawn(async move {
-        let results = execute_with_conn(query_conn.as_ref(), &first_query);
-        match results {
-          Ok(ref rows) => {
-            log::info!("{:?} rows, {:?} affected", rows.rows.len(), rows.rows_affected);
-          },
-          Err(ref e) => {
-            log::error!("{e:?}");
-          },
-        };
-        Ok(QueryResultsWithMetadata::with_display_statement_type(
-          results,
-          statement_type,
-          display_statement_type,
-        ))
-      })),
-    };
-
-    self.task = Some(task);
+    self.task = Some(OracleTask::Query(tokio::spawn(async move {
+      let results = if use_query_api {
+        query_with_conn(query_conn.as_ref(), &first_query)
+      } else {
+        execute_with_conn(query_conn.as_ref(), &first_query)
+      };
+      QueryResultsWithMetadata::with_display_statement_type(
+        results,
+        statement_type,
+        display_statement_type,
+      )
+    })));
 
     Ok(())
   }
@@ -176,7 +160,32 @@ impl Database for OracleDriver {
   }
 
   async fn start_tx(&mut self, query: String) -> Result<()> {
-    Self::start_query(self, query, false).await
+    let (first_query, stmt) = super::get_first_query(query, Driver::Oracle)?;
+    let statement_type = Some(super::get_statement_for_execution_type(&stmt));
+    let display_statement_type = Some(super::get_display_statement_for_execution_type(&stmt));
+    let pool = self.pool.clone().unwrap();
+
+    let conn = Arc::new(pool.get()?);
+    let query_conn = conn.clone();
+    self.querying_conn = Some(conn);
+    self.task = Some(OracleTask::TxStart(tokio::spawn(async move {
+      let results = execute_with_conn(query_conn.as_ref(), &first_query);
+      match results {
+        Ok(ref rows) => {
+          log::info!("{:?} rows, {:?} affected", rows.rows.len(), rows.rows_affected);
+        },
+        Err(ref e) => {
+          log::error!("{e:?}");
+        },
+      };
+      Ok(QueryResultsWithMetadata::with_display_statement_type(
+        results,
+        statement_type,
+        display_statement_type,
+      ))
+    })));
+
+    Ok(())
   }
 
   async fn commit_tx(&mut self) -> Result<Option<QueryResultsWithMetadata>> {

--- a/src/database/oracle/mod.rs
+++ b/src/database/oracle/mod.rs
@@ -72,7 +72,12 @@ impl Database for OracleDriver {
       let results = if use_query_api {
         query_with_conn(query_conn.as_ref(), &first_query)
       } else {
-        execute_with_conn(query_conn.as_ref(), &first_query)
+        execute_with_conn(query_conn.as_ref(), &first_query).and_then(|rows| {
+          query_conn
+            .commit()
+            .map_err(|e| color_eyre::eyre::eyre!("Error committing query: {}", e))?;
+          Ok(rows)
+        })
       };
       QueryResultsWithMetadata::with_display_statement_type(
         results,

--- a/src/database/oracle/mod.rs
+++ b/src/database/oracle/mod.rs
@@ -51,18 +51,18 @@ impl Database for OracleDriver {
   }
 
   async fn start_query(&mut self, query: String, bypass_parser: bool) -> Result<()> {
-    let (first_query, statement_type) = if bypass_parser {
-      (query, None)
+    let (first_query, statement_type, routing_statement_type) = if bypass_parser {
+      (query, None, None)
     } else {
       let (first, stmt) = super::get_first_query(query, Driver::Oracle)?;
-      (first, Some(super::get_statement_for_execution_type(&stmt)))
+      (first, Some(super::get_statement_for_execution_type(&stmt)), Some(stmt))
     };
     let pool = self.pool.clone().unwrap();
 
     let conn = Arc::new(pool.get()?);
     let query_conn = conn.clone();
     self.querying_conn = Some(conn);
-    let task = match statement_type {
+    let task = match routing_statement_type {
       Some(Statement::Query(_)) => OracleTask::Query(tokio::spawn(async move {
         let results = query_with_conn(query_conn.as_ref(), &first_query);
         QueryResultsWithMetadata { results, statement_type }

--- a/src/database/oracle/mod.rs
+++ b/src/database/oracle/mod.rs
@@ -55,7 +55,7 @@ impl Database for OracleDriver {
       (query, None)
     } else {
       let (first, stmt) = super::get_first_query(query, Driver::Oracle)?;
-      (first, Some(stmt))
+      (first, Some(super::get_statement_for_execution_type(&stmt)))
     };
     let pool = self.pool.clone().unwrap();
 

--- a/src/database/postgresql.rs
+++ b/src/database/postgresql.rs
@@ -9,7 +9,6 @@ use std::{
 use async_trait::async_trait;
 use color_eyre::eyre::{self, Result};
 use futures::stream::StreamExt;
-use sqlparser::ast::Statement;
 use sqlx::{
   Column, Either, Row, ValueRef,
   pool::PoolConnection,
@@ -465,7 +464,7 @@ where
   let first_query = super::get_first_query(query.to_string(), Driver::Postgres);
   match first_query {
     Ok((first_query, statement_type)) => match statement_type {
-      Statement::Explain { .. } => {
+      statement_type if super::should_stream_tx_results(&statement_type) => {
         let result = query_with_stream(&mut *tx, &first_query).await;
         match result {
           Ok(result) => (Ok(Either::Right(result)), tx),
@@ -715,7 +714,7 @@ fn parse_value(
 
 #[cfg(test)]
 mod tests {
-  use sqlparser::{dialect::PostgreSqlDialect, parser::ParserError};
+  use sqlparser::{ast::Statement, dialect::PostgreSqlDialect, parser::ParserError};
 
   use super::*;
   use crate::database::{ExecutionType, ParseError, get_execution_type, get_first_query};

--- a/src/database/postgresql.rs
+++ b/src/database/postgresql.rs
@@ -213,6 +213,7 @@ impl Database for PostgresDriver<'_> {
 
   async fn start_tx(&mut self, query: String) -> Result<()> {
     let (first_query, statement_type) = super::get_first_query(query, Driver::Postgres)?;
+    let statement_type = super::get_statement_for_execution_type(&statement_type);
     let mut tx = self.pool.clone().unwrap().begin().await?;
     let pid = sqlx::raw_sql("SELECT pg_backend_pid()").fetch_one(&mut *tx).await?.get::<i32, _>(0);
     log::info!("Starting transaction with PID {}", pid.clone());

--- a/src/database/postgresql.rs
+++ b/src/database/postgresql.rs
@@ -115,7 +115,7 @@ impl Database for PostgresDriver<'_> {
           log::error!("{e:?}");
         },
       };
-      QueryResultsWithMetadata { results, statement_type: statement_type.clone() }
+      QueryResultsWithMetadata::new(results, statement_type.clone())
     })));
     Ok(())
   }
@@ -185,20 +185,29 @@ impl Database for PostgresDriver<'_> {
           };
           match result {
             // if tx failed to start, return the error immediately
-            QueryResultsWithMetadata { results: Err(e), statement_type } => {
+            QueryResultsWithMetadata {
+              results: Err(e),
+              statement_type,
+              display_statement_type,
+            } => {
               log::error!("Transaction didn't start: {e:?}");
               self.querying_conn = None;
               self.querying_pid = None;
               (
-                DbTaskResult::Finished(QueryResultsWithMetadata {
-                  results: Err(e),
+                DbTaskResult::Finished(QueryResultsWithMetadata::with_display_statement_type(
+                  Err(e),
                   statement_type,
-                }),
+                  display_statement_type,
+                )),
                 None,
               )
             },
             _ => (
-              DbTaskResult::ConfirmTx(rows_affected, result.statement_type.clone()),
+              DbTaskResult::ConfirmTx(
+                rows_affected,
+                result.statement_type.clone(),
+                result.display_statement_type.clone(),
+              ),
               Some(PostgresTask::TxPending(Box::new((tx, result)))),
             ),
           }
@@ -212,6 +221,7 @@ impl Database for PostgresDriver<'_> {
 
   async fn start_tx(&mut self, query: String) -> Result<()> {
     let (first_query, statement_type) = super::get_first_query(query, Driver::Postgres)?;
+    let display_statement_type = super::get_display_statement_for_execution_type(&statement_type);
     let statement_type = super::get_statement_for_execution_type(&statement_type);
     let mut tx = self.pool.clone().unwrap().begin().await?;
     let pid = sqlx::raw_sql("SELECT pg_backend_pid()").fetch_one(&mut *tx).await?.get::<i32, _>(0);
@@ -230,17 +240,32 @@ impl Database for PostgresDriver<'_> {
                 rows_affected: Some(rows_affected),
               }),
               statement_type: Some(statement_type),
+              display_statement_type: Some(display_statement_type),
             },
             tx,
           )
         },
         Ok(Either::Right(rows)) => {
           log::info!("{:?} rows affected", rows.rows_affected);
-          (QueryResultsWithMetadata { results: Ok(rows), statement_type: Some(statement_type) }, tx)
+          (
+            QueryResultsWithMetadata::with_display_statement_type(
+              Ok(rows),
+              Some(statement_type),
+              Some(display_statement_type),
+            ),
+            tx,
+          )
         },
         Err(e) => {
           log::error!("{e:?}");
-          (QueryResultsWithMetadata { results: Err(e), statement_type: Some(statement_type) }, tx)
+          (
+            QueryResultsWithMetadata::with_display_statement_type(
+              Err(e),
+              Some(statement_type),
+              Some(display_statement_type),
+            ),
+            tx,
+          )
         },
       }
     })));

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -65,7 +65,7 @@ impl Database for SqliteDriver<'_> {
           log::error!("{e:?}");
         },
       };
-      QueryResultsWithMetadata { results, statement_type: statement_type.clone() }
+      QueryResultsWithMetadata::new(results, statement_type.clone())
     })));
     Ok(())
   }
@@ -106,18 +106,27 @@ impl Database for SqliteDriver<'_> {
           };
           match result {
             // if tx failed to start, return the error immediately
-            QueryResultsWithMetadata { results: Err(e), statement_type } => {
+            QueryResultsWithMetadata {
+              results: Err(e),
+              statement_type,
+              display_statement_type,
+            } => {
               log::error!("Transaction didn't start: {e:?}");
               (
-                DbTaskResult::Finished(QueryResultsWithMetadata {
-                  results: Err(e),
+                DbTaskResult::Finished(QueryResultsWithMetadata::with_display_statement_type(
+                  Err(e),
                   statement_type,
-                }),
+                  display_statement_type,
+                )),
                 None,
               )
             },
             _ => (
-              DbTaskResult::ConfirmTx(rows_affected, result.statement_type.clone()),
+              DbTaskResult::ConfirmTx(
+                rows_affected,
+                result.statement_type.clone(),
+                result.display_statement_type.clone(),
+              ),
               Some(SqliteTask::TxPending(Box::new((tx, result)))),
             ),
           }
@@ -131,6 +140,7 @@ impl Database for SqliteDriver<'_> {
 
   async fn start_tx(&mut self, query: String) -> Result<()> {
     let (first_query, statement_type) = super::get_first_query(query, Driver::Sqlite)?;
+    let display_statement_type = super::get_display_statement_for_execution_type(&statement_type);
     let statement_type = super::get_statement_for_execution_type(&statement_type);
     let tx = self.pool.as_mut().unwrap().begin().await?;
     self.task = Some(SqliteTask::TxStart(tokio::spawn(async move {
@@ -146,17 +156,32 @@ impl Database for SqliteDriver<'_> {
                 rows_affected: Some(rows_affected),
               }),
               statement_type: Some(statement_type),
+              display_statement_type: Some(display_statement_type),
             },
             tx,
           )
         },
         Ok(Either::Right(rows)) => {
           log::info!("{:?} rows affected", rows.rows_affected);
-          (QueryResultsWithMetadata { results: Ok(rows), statement_type: Some(statement_type) }, tx)
+          (
+            QueryResultsWithMetadata::with_display_statement_type(
+              Ok(rows),
+              Some(statement_type),
+              Some(display_statement_type),
+            ),
+            tx,
+          )
         },
         Err(e) => {
           log::error!("{e:?}");
-          (QueryResultsWithMetadata { results: Err(e), statement_type: Some(statement_type) }, tx)
+          (
+            QueryResultsWithMetadata::with_display_statement_type(
+              Err(e),
+              Some(statement_type),
+              Some(display_statement_type),
+            ),
+            tx,
+          )
         },
       }
     })));

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -9,7 +9,6 @@ use std::{
 use async_trait::async_trait;
 use color_eyre::eyre::{self, Result};
 use futures::stream::StreamExt;
-use sqlparser::ast::Statement;
 use sqlx::{
   Column, Either, Row, ValueRef,
   sqlite::{Sqlite, SqliteConnectOptions, SqlitePoolOptions},
@@ -307,7 +306,7 @@ where
   let first_query = super::get_first_query(query.to_string(), Driver::Sqlite);
   match first_query {
     Ok((first_query, statement_type)) => match statement_type {
-      Statement::Explain { .. } => {
+      statement_type if super::should_stream_tx_results(&statement_type) => {
         let result = query_with_stream(&mut *tx, &first_query).await;
         match result {
           Ok(result) => (Ok(Either::Right(result)), tx),

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -132,6 +132,7 @@ impl Database for SqliteDriver<'_> {
 
   async fn start_tx(&mut self, query: String) -> Result<()> {
     let (first_query, statement_type) = super::get_first_query(query, Driver::Sqlite)?;
+    let statement_type = super::get_statement_for_execution_type(&statement_type);
     let tx = self.pool.as_mut().unwrap().begin().await?;
     self.task = Some(SqliteTask::TxStart(tokio::spawn(async move {
       let (results, tx) = query_with_tx(tx, &first_query).await;

--- a/src/popups/confirm_tx.rs
+++ b/src/popups/confirm_tx.rs
@@ -8,11 +8,16 @@ use crate::database::statement_type_string;
 pub struct ConfirmTx {
   rows_affected: Option<u64>,
   statement_type: Option<Statement>,
+  display_statement_type: Option<Statement>,
 }
 
 impl ConfirmTx {
-  pub fn new(rows_affected: Option<u64>, statement_type: Option<Statement>) -> Self {
-    Self { rows_affected, statement_type }
+  pub fn new(
+    rows_affected: Option<u64>,
+    statement_type: Option<Statement>,
+    display_statement_type: Option<Statement>,
+  ) -> Self {
+    Self { rows_affected, statement_type, display_statement_type }
   }
 }
 
@@ -31,6 +36,13 @@ impl PopUp for ConfirmTx {
 
   fn get_cta_text(&self, app_state: &crate::app::AppState) -> String {
     let rows_affected = self.rows_affected.unwrap_or_default();
+    if matches!(self.display_statement_type, Some(Statement::Explain { .. })) {
+      return format!(
+        "Are you sure you want to run an EXPLAIN ANALYZE that will {} rows?",
+        statement_type_string(self.statement_type.clone()).to_uppercase(),
+      );
+    }
+
     match self.statement_type.clone() {
       None => {
         format!(
@@ -42,12 +54,6 @@ impl PopUp for ConfirmTx {
           "Are you sure you want to {} {} rows?",
           statement_type_string(self.statement_type.clone()).to_uppercase(),
           rows_affected
-        )
-      },
-      Some(Statement::Explain { statement, .. }) => {
-        format!(
-          "Are you sure you want to run an EXPLAIN ANALYZE that will {} rows?",
-          statement_type_string(Some(*statement.clone())).to_uppercase(),
         )
       },
       _ => {


### PR DESCRIPTION
closes #280 

## Summary
- Traverse parsed query and CTE bodies when selecting execution type.
- Preserve the statement that determines the highest-risk execution type so confirmation UI reports `UPDATE`/`DELETE` instead of outer `QUERY`.
- Store the representative statement in transaction metadata across database drivers.
- Add regression coverage for CTE-wrapped writes and `EXPLAIN ANALYZE` behavior.

## Testing
- `cargo test database::tests::`
- `cargo test test_execution_type`
- `git diff --check`
- `cargo test` (fails only in existing `config::tests::test_config`, expecting `mouse_mode == Some(true)` but receiving `Some(false)`)