### PR TITLE
add a reenter-password flag for saved connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Options:
   -u, --url <URL>            Full connection URL for the database, e.g. postgres://username:password@localhost:5432/dbname
       --username <USERNAME>  Username for database connection
       --password <PASSWORD>  Password for database connection
+  -R, --reenter-password     Reenter the password for a saved database connection
       --host <HOST>          Host for database connection (ex. localhost)
       --port <PORT>          Port for database connection (ex. 5432)
       --database <DATABASE>  Name of database for connection (ex. postgres)
@@ -371,6 +372,9 @@ if no database connection in the config is set as the default connection,
 a prompt will appear to select the desired database. The user will also be 
 prompted for the password for the selected database and will have the option to 
 store it in a platform specific keychain for future reuse.
+Pass `--reenter-password` (or `-R`) to revoke a saved keychain password before
+being prompted to enter and optionally save its replacement.
+
 future plans for database connections include switching database without having to restart rainfrog.
 
 <!-- TOC --><a name="keybindings"></a>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,6 +40,14 @@ pub struct Cli {
   #[arg(long = "password", value_name = "PASSWORD", help = "Password for database connection")]
   pub password: Option<String>,
 
+  #[arg(
+    short = 'R',
+    long = "reenter-password",
+    action = clap::ArgAction::SetTrue,
+    help = "Reenter the password for a saved database connection"
+  )]
+  pub reenter_password: bool,
+
   #[arg(long = "host", value_name = "HOST", help = "Host for database connection (ex. localhost)")]
   pub host: Option<String>,
 
@@ -307,5 +315,23 @@ mod tests {
   fn enable_cleartext_plugin_flag_sets_true() {
     let cli = Cli::parse_from(["rainfrog", "--enable-cleartext-plugin"]);
     assert!(cli.enable_cleartext_plugin);
+  }
+
+  #[test]
+  fn reenter_password_defaults_to_false() {
+    let cli = Cli::parse_from(["rainfrog"]);
+    assert!(!cli.reenter_password);
+  }
+
+  #[test]
+  fn reenter_password_long_flag_sets_true() {
+    let cli = Cli::parse_from(["rainfrog", "--reenter-password"]);
+    assert!(cli.reenter_password);
+  }
+
+  #[test]
+  fn reenter_password_short_flag_sets_true() {
+    let cli = Cli::parse_from(["rainfrog", "-R"]);
+    assert!(cli.reenter_password);
   }
 }

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Write};
 
-use color_eyre::eyre;
+use color_eyre::eyre::{self, WrapErr};
 use keyring::Entry;
 
 use crate::Result;
@@ -13,8 +13,23 @@ impl AsRef<str> for Password {
   }
 }
 
-pub fn get_password(connection_name: &str, username: &str) -> Result<Password> {
+fn revoke_password(entry: &Entry) -> Result<()> {
+  match entry.delete_credential() {
+    Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+    Err(e) => Err(e).wrap_err("Failed to revoke password from keyring"),
+  }
+}
+
+pub fn get_password(
+  connection_name: &str,
+  username: &str,
+  reenter_password: bool,
+) -> Result<Password> {
   let entry = Entry::new("rainfrog", &format!("{connection_name}-{username}"))?;
+
+  if reenter_password {
+    revoke_password(&entry)?;
+  }
 
   match entry.get_password() {
     Ok(password) => {
@@ -47,5 +62,45 @@ pub fn get_password(connection_name: &str, username: &str) -> Result<Password> {
       },
       _ => Err(eyre::Report::msg("Failed to extract password from secret: {e:?}")),
     },
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use keyring::mock::MockCredential;
+
+  fn mock_entry() -> Entry {
+    Entry::new_with_credential(Box::new(MockCredential::default()))
+  }
+
+  #[test]
+  fn revokes_existing_password() {
+    let entry = mock_entry();
+    entry.set_password("incorrect-password").unwrap();
+
+    revoke_password(&entry).unwrap();
+
+    assert!(matches!(entry.get_password(), Err(keyring::Error::NoEntry)));
+  }
+
+  #[test]
+  fn treats_missing_password_as_already_revoked() {
+    let entry = mock_entry();
+
+    revoke_password(&entry).unwrap();
+  }
+
+  #[test]
+  fn propagates_keyring_revocation_errors() {
+    let entry = mock_entry();
+    let credential = entry.get_credential().downcast_ref::<MockCredential>().unwrap();
+    credential.set_error(keyring::Error::NoStorageAccess(Box::new(std::io::Error::other(
+      "keyring is locked",
+    ))));
+
+    let error = revoke_password(&entry).unwrap_err();
+
+    assert!(error.to_string().contains("Failed to revoke password from keyring"));
   }
 }

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -20,6 +20,30 @@ fn revoke_password(entry: &Entry) -> Result<()> {
   }
 }
 
+fn prompt_for_password(entry: &Entry, connection_name: &str, username: &str) -> Result<Password> {
+  println!("{username}@{connection_name}");
+  let password = rpassword::prompt_password("Password: ")?;
+
+  print!("Save password (Y/n): ");
+  let mut save = String::new();
+  io::stdout().flush()?;
+  io::stdin().read_line(&mut save)?;
+  match save.trim() {
+    "" | "Y" | "y" => {
+      entry.set_password(&password)?;
+      println!("Password saved in keyring");
+      Ok(())
+    },
+    "n" | "N" => {
+      println!("Password not saved in keyring");
+      Ok(())
+    },
+    _ => Err(eyre::Report::msg("Unrecognized save option")),
+  }?;
+
+  Ok(Password(password))
+}
+
 pub fn get_password(
   connection_name: &str,
   username: &str,
@@ -29,6 +53,7 @@ pub fn get_password(
 
   if reenter_password {
     revoke_password(&entry)?;
+    return prompt_for_password(&entry, connection_name, username);
   }
 
   match entry.get_password() {
@@ -37,29 +62,7 @@ pub fn get_password(
       Ok(Password(password))
     },
     Err(e) => match e {
-      keyring::Error::NoEntry => {
-        println!("{username}@{connection_name}");
-        let password = rpassword::prompt_password("Password: ")?;
-
-        print!("Save password (Y/n): ");
-        let mut save = String::new();
-        io::stdout().flush()?;
-        io::stdin().read_line(&mut save)?;
-        match save.trim() {
-          "" | "Y" | "y" => {
-            entry.set_password(&password)?;
-            println!("Password saved in keyring");
-            Ok(())
-          },
-          "n" | "N" => {
-            println!("Password not saved in keyring");
-            Ok(())
-          },
-          _ => Err(eyre::Report::msg("Unrecognized save option")),
-        }?;
-
-        Ok(Password(password))
-      },
+      keyring::Error::NoEntry => prompt_for_password(&entry, connection_name, username),
       _ => Err(eyre::Report::msg("Failed to extract password from secret: {e:?}")),
     },
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ fn resolve_driver(args: &mut Cli, config: &Config) -> Result<Driver> {
         let url = match conn.connection {
           ConnectionString::Raw { connection_string } => Ok(connection_string),
           ConnectionString::Structured { details } => {
-            let password = get_password(&name, &details.username)?;
+            let password = get_password(&name, &details.username, args.reenter_password)?;
             details.connection_string(conn.driver, password)
           },
         }?;


### PR DESCRIPTION
closes #296 

## Summary
- add a `--reenter-password` / `-R` flag to force keyring password renewal for saved database connections
- revoke any stored password before prompting for a replacement
- document the new option in the README and cover the new CLI and keyring paths with tests

## Testing
- added CLI tests for the default, long flag, and short flag behavior
- added keyring tests for revocation, missing entries, and error propagation