### PR TITLE
handle bracketed paste in search fields and favorite naming

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -232,6 +232,12 @@ impl App {
           tui::Event::Render => action_tx.send(Action::Render)?,
           tui::Event::Resize(x, y) => action_tx.send(Action::Resize(x, y))?,
           tui::Event::Mouse(event) => self.last_frame_mouse_event = Some(event),
+          tui::Event::Paste(ref text) => {
+            if let Some(popup) = &mut self.popup {
+              popup.handle_paste_events(text, &mut self.state)?;
+              event_consumed = true;
+            }
+          },
           tui::Event::Key(key) => {
             if let Some(keymap) = self.config.keybindings.get(&self.state.focus) {
               if let Some(action) = keymap.get(&vec![key]) {

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -232,3 +232,24 @@ impl Component for Editor<'_> {
     Ok(())
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::{components::app_state_with_focus, tui::Event};
+
+  #[test]
+  fn paste_keeps_multiline_editor_input() {
+    let mut editor = Editor::new();
+
+    editor
+      .handle_events(
+        Some(Event::Paste("select 1;\nselect 2;".to_string())),
+        Vec::new(),
+        &app_state_with_focus(Focus::Editor),
+      )
+      .unwrap();
+
+    assert_eq!(editor.textarea.lines(), &["select 1;", "select 2;"]);
+  }
+}

--- a/src/components/favorites.rs
+++ b/src/components/favorites.rs
@@ -149,47 +149,6 @@ impl FavoriteEntries {
   }
 }
 
-#[cfg(test)]
-mod tests {
-  use super::*;
-  use crate::{components::app_state_with_focus, tui::Event};
-
-  #[test]
-  fn paste_appends_to_focused_search_and_resets_selection() {
-    let mut favorites = Favorites::new();
-    favorites.search = Some("saved".to_string());
-    favorites.search_focused = true;
-    favorites.list_state.select(Some(2));
-
-    favorites
-      .handle_events(
-        Some(Event::Paste(" query\ntext".to_string())),
-        Vec::new(),
-        &app_state_with_focus(Focus::Favorites),
-      )
-      .unwrap();
-
-    assert_eq!(favorites.search.as_deref(), Some("saved query\ntext"));
-    assert_eq!(favorites.list_state.selected(), None);
-  }
-
-  #[test]
-  fn paste_is_ignored_when_search_is_not_focused() {
-    let mut favorites = Favorites::new();
-    favorites.search = Some("saved".to_string());
-
-    favorites
-      .handle_events(
-        Some(Event::Paste(" query".to_string())),
-        Vec::new(),
-        &app_state_with_focus(Focus::Favorites),
-      )
-      .unwrap();
-
-    assert_eq!(favorites.search.as_deref(), Some("saved"));
-  }
-}
-
 impl Favorites {
   pub fn new() -> Self {
     Favorites {
@@ -436,5 +395,46 @@ impl Component for Favorites {
     f.render_stateful_widget(vertical_scrollbar, scrollbar_margin, &mut vertical_scrollbar_state);
 
     Ok(())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::{components::app_state_with_focus, tui::Event};
+
+  #[test]
+  fn paste_appends_to_focused_search_and_resets_selection() {
+    let mut favorites = Favorites::new();
+    favorites.search = Some("saved".to_string());
+    favorites.search_focused = true;
+    favorites.list_state.select(Some(2));
+
+    favorites
+      .handle_events(
+        Some(Event::Paste(" query\ntext".to_string())),
+        Vec::new(),
+        &app_state_with_focus(Focus::Favorites),
+      )
+      .unwrap();
+
+    assert_eq!(favorites.search.as_deref(), Some("saved query\ntext"));
+    assert_eq!(favorites.list_state.selected(), None);
+  }
+
+  #[test]
+  fn paste_is_ignored_when_search_is_not_focused() {
+    let mut favorites = Favorites::new();
+    favorites.search = Some("saved".to_string());
+
+    favorites
+      .handle_events(
+        Some(Event::Paste(" query".to_string())),
+        Vec::new(),
+        &app_state_with_focus(Focus::Favorites),
+      )
+      .unwrap();
+
+    assert_eq!(favorites.search.as_deref(), Some("saved"));
   }
 }

--- a/src/components/favorites.rs
+++ b/src/components/favorites.rs
@@ -44,6 +44,11 @@ impl FavoriteEntry {
 }
 
 impl FavoriteEntries {
+  #[cfg(test)]
+  pub(crate) fn empty_for_test() -> Self {
+    Self { dir: PathBuf::new(), entries: Vec::new() }
+  }
+
   pub fn new(favorites_dir: &Path) -> Result<Self> {
     if !favorites_dir.exists() {
       std::fs::create_dir_all(favorites_dir)?;
@@ -141,6 +146,47 @@ impl FavoriteEntries {
     }
 
     Ok(out)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::{components::app_state_with_focus, tui::Event};
+
+  #[test]
+  fn paste_appends_to_focused_search_and_resets_selection() {
+    let mut favorites = Favorites::new();
+    favorites.search = Some("saved".to_string());
+    favorites.search_focused = true;
+    favorites.list_state.select(Some(2));
+
+    favorites
+      .handle_events(
+        Some(Event::Paste(" query\ntext".to_string())),
+        Vec::new(),
+        &app_state_with_focus(Focus::Favorites),
+      )
+      .unwrap();
+
+    assert_eq!(favorites.search.as_deref(), Some("saved query\ntext"));
+    assert_eq!(favorites.list_state.selected(), None);
+  }
+
+  #[test]
+  fn paste_is_ignored_when_search_is_not_focused() {
+    let mut favorites = Favorites::new();
+    favorites.search = Some("saved".to_string());
+
+    favorites
+      .handle_events(
+        Some(Event::Paste(" query".to_string())),
+        Vec::new(),
+        &app_state_with_focus(Focus::Favorites),
+      )
+      .unwrap();
+
+    assert_eq!(favorites.search.as_deref(), Some("saved"));
   }
 }
 
@@ -285,6 +331,17 @@ impl Component for Favorites {
       },
       _ => {},
     };
+    Ok(None)
+  }
+
+  fn handle_paste_events(&mut self, text: &str, app_state: &AppState) -> Result<Option<Action>> {
+    if app_state.focus != Focus::Favorites || !self.search_focused {
+      return Ok(None);
+    }
+    if let Some(search) = self.search.as_mut() {
+      search.push_str(text);
+      self.list_state = ListState::default();
+    }
     Ok(None)
   }
 

--- a/src/components/menu.rs
+++ b/src/components/menu.rs
@@ -349,54 +349,6 @@ impl SettableTableList<'_> for Menu {
   }
 }
 
-#[cfg(test)]
-mod tests {
-  use super::*;
-  use crate::{components::app_state_with_focus, tui::Event};
-
-  #[test]
-  fn paste_appends_to_focused_search_and_selects_first_match() {
-    let mut menu = Menu::new();
-    menu.menu_focus = MenuFocus::Tables;
-    menu.search = Some("user".to_string());
-    menu.search_focused = true;
-    menu.table_map.insert(
-      "public".to_string(),
-      MenuSchemaItems {
-        tables: vec!["users".to_string(), "orders".to_string()],
-        ..MenuSchemaItems::default()
-      },
-    );
-
-    menu
-      .handle_events(
-        Some(Event::Paste("s\n".to_string())),
-        Vec::new(),
-        &app_state_with_focus(Focus::Menu),
-      )
-      .unwrap();
-
-    assert_eq!(menu.search.as_deref(), Some("users\n"));
-    assert_eq!(menu.list_state.selected(), Some(1));
-  }
-
-  #[test]
-  fn paste_is_ignored_when_search_is_not_focused() {
-    let mut menu = Menu::new();
-    menu.search = Some("user".to_string());
-
-    menu
-      .handle_events(
-        Some(Event::Paste("s".to_string())),
-        Vec::new(),
-        &app_state_with_focus(Focus::Menu),
-      )
-      .unwrap();
-
-    assert_eq!(menu.search.as_deref(), Some("user"));
-  }
-}
-
 impl Component for Menu {
   fn register_action_handler(&mut self, tx: UnboundedSender<Action>) -> Result<()> {
     self.command_tx = Some(tx);
@@ -733,5 +685,53 @@ impl Component for Menu {
 
     f.render_widget(parent_block, area);
     Ok(())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::{components::app_state_with_focus, tui::Event};
+
+  #[test]
+  fn paste_appends_to_focused_search_and_selects_first_match() {
+    let mut menu = Menu::new();
+    menu.menu_focus = MenuFocus::Tables;
+    menu.search = Some("user".to_string());
+    menu.search_focused = true;
+    menu.table_map.insert(
+      "public".to_string(),
+      MenuSchemaItems {
+        tables: vec!["users".to_string(), "orders".to_string()],
+        ..MenuSchemaItems::default()
+      },
+    );
+
+    menu
+      .handle_events(
+        Some(Event::Paste("s\n".to_string())),
+        Vec::new(),
+        &app_state_with_focus(Focus::Menu),
+      )
+      .unwrap();
+
+    assert_eq!(menu.search.as_deref(), Some("users\n"));
+    assert_eq!(menu.list_state.selected(), Some(1));
+  }
+
+  #[test]
+  fn paste_is_ignored_when_search_is_not_focused() {
+    let mut menu = Menu::new();
+    menu.search = Some("user".to_string());
+
+    menu
+      .handle_events(
+        Some(Event::Paste("s".to_string())),
+        Vec::new(),
+        &app_state_with_focus(Focus::Menu),
+      )
+      .unwrap();
+
+    assert_eq!(menu.search.as_deref(), Some("user"));
   }
 }

--- a/src/components/menu.rs
+++ b/src/components/menu.rs
@@ -349,6 +349,54 @@ impl SettableTableList<'_> for Menu {
   }
 }
 
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::{components::app_state_with_focus, tui::Event};
+
+  #[test]
+  fn paste_appends_to_focused_search_and_selects_first_match() {
+    let mut menu = Menu::new();
+    menu.menu_focus = MenuFocus::Tables;
+    menu.search = Some("user".to_string());
+    menu.search_focused = true;
+    menu.table_map.insert(
+      "public".to_string(),
+      MenuSchemaItems {
+        tables: vec!["users".to_string(), "orders".to_string()],
+        ..MenuSchemaItems::default()
+      },
+    );
+
+    menu
+      .handle_events(
+        Some(Event::Paste("s\n".to_string())),
+        Vec::new(),
+        &app_state_with_focus(Focus::Menu),
+      )
+      .unwrap();
+
+    assert_eq!(menu.search.as_deref(), Some("users\n"));
+    assert_eq!(menu.list_state.selected(), Some(1));
+  }
+
+  #[test]
+  fn paste_is_ignored_when_search_is_not_focused() {
+    let mut menu = Menu::new();
+    menu.search = Some("user".to_string());
+
+    menu
+      .handle_events(
+        Some(Event::Paste("s".to_string())),
+        Vec::new(),
+        &app_state_with_focus(Focus::Menu),
+      )
+      .unwrap();
+
+    assert_eq!(menu.search.as_deref(), Some("user"));
+  }
+}
+
 impl Component for Menu {
   fn register_action_handler(&mut self, tx: UnboundedSender<Action>) -> Result<()> {
     self.command_tx = Some(tx);
@@ -476,6 +524,18 @@ impl Component for Menu {
         }
       },
       _ => {},
+    }
+    Ok(None)
+  }
+
+  fn handle_paste_events(&mut self, text: &str, app_state: &AppState) -> Result<Option<Action>> {
+    if app_state.focus != Focus::Menu || !self.search_focused {
+      return Ok(None);
+    }
+    if let Some(search) = self.search.as_mut() {
+      search.push_str(text);
+      let entries = self.filtered_entries();
+      self.list_state = ListState::default().with_selected(Self::first_selectable_index(&entries));
     }
     Ok(None)
   }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -26,6 +26,19 @@ pub mod favorites;
 pub mod history;
 pub mod menu;
 pub mod scroll_table;
+
+#[cfg(test)]
+pub(crate) fn app_state_with_focus(focus: crate::focus::Focus) -> AppState {
+  AppState {
+    focus,
+    history: Vec::new(),
+    favorites: favorites::FavoriteEntries::empty_for_test(),
+    last_query_start: None,
+    last_query_end: None,
+    query_task_running: false,
+  }
+}
+
 pub trait Component {
   /// Register an action handler that can send actions for processing if necessary.
   ///
@@ -83,9 +96,15 @@ pub trait Component {
     let r = match event {
       Some(Event::Key(key_event)) => self.handle_key_events(key_event, app_state)?,
       Some(Event::Mouse(mouse_event)) => self.handle_mouse_events(mouse_event, app_state)?,
+      Some(Event::Paste(text)) => self.handle_paste_events(&text, app_state)?,
       _ => None,
     };
     Ok(r)
+  }
+  /// Handle bracketed paste events and produce actions if necessary.
+  #[allow(unused_variables)]
+  fn handle_paste_events(&mut self, text: &str, app_state: &AppState) -> Result<Option<Action>> {
+    Ok(None)
   }
   /// Handle key events and produce actions if necessary.
   ///

--- a/src/popups/mod.rs
+++ b/src/popups/mod.rs
@@ -38,6 +38,11 @@ pub trait PopUp {
   ) -> Result<Option<PopUpPayload>>;
 
   #[allow(unused_variables)]
+  fn handle_paste_events(&mut self, text: &str, app_state: &mut AppState) -> Result<()> {
+    Ok(())
+  }
+
+  #[allow(unused_variables)]
   fn get_cta_text(&self, app_state: &AppState) -> String {
     "".to_string()
   }

--- a/src/popups/name_favorite.rs
+++ b/src/popups/name_favorite.rs
@@ -13,6 +13,23 @@ impl NameFavorite {
   pub fn new(existing_names: Vec<String>, query_lines: Vec<String>) -> Self {
     Self { name: "".to_string(), existing_names, query_lines }
   }
+
+  fn push_char(&mut self, c: char) {
+    // Preserve the existing favorite-name sanitization for typed and pasted input.
+    if c.is_whitespace()
+      || c.is_ascii_whitespace()
+      || (c.is_ascii_punctuation() && c != '_' && c != '-')
+    {
+      return;
+    }
+    self.name.push(c);
+  }
+
+  fn push_input(&mut self, input: &str) {
+    for c in input.chars() {
+      self.push_char(c);
+    }
+  }
 }
 
 impl PopUp for NameFavorite {
@@ -23,14 +40,7 @@ impl PopUp for NameFavorite {
   ) -> color_eyre::eyre::Result<Option<PopUpPayload>> {
     match key.code {
       KeyCode::Char(c) => {
-        // ignore invalid characters
-        if c.is_whitespace()
-          || c.is_ascii_whitespace()
-          || (c.is_ascii_punctuation() && c != '_' && c != '-')
-        {
-          return Ok(None);
-        }
-        self.name.push(c);
+        self.push_char(c);
         Ok(None)
       },
       KeyCode::Enter => {
@@ -54,6 +64,15 @@ impl PopUp for NameFavorite {
     }
   }
 
+  fn handle_paste_events(
+    &mut self,
+    text: &str,
+    app_state: &mut crate::app::AppState,
+  ) -> color_eyre::eyre::Result<()> {
+    self.push_input(text);
+    Ok(())
+  }
+
   fn get_cta_text(&self, app_state: &crate::app::AppState) -> String {
     "Input a name for the favorite and then press [Enter]; press [Esc] to cancel. No spaces or special characters allowed.".to_string()
   }
@@ -68,5 +87,21 @@ impl PopUp for NameFavorite {
         ""
       }
     )
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::{components::app_state_with_focus, focus::Focus};
+
+  #[test]
+  fn paste_uses_the_same_name_sanitization_as_typed_input() {
+    let mut favorite = NameFavorite::new(Vec::new(), vec!["select 1".to_string()]);
+    let mut app_state = app_state_with_focus(Focus::PopUp);
+
+    favorite.handle_paste_events("my favorite!?_v2-東京\n", &mut app_state).unwrap();
+
+    assert_eq!(favorite.name, "myfavorite_v2-東京");
   }
 }


### PR DESCRIPTION
closes #290 

## Summary
- route bracketed paste events into the active popup or component so pasted text is handled instead of dropped
- keep multiline editor input intact during paste
- support paste-aware search updates in favorites and menu, including selection reset/recompute
- reuse the same favorite-name sanitization for pasted input as typed characters
- add unit tests covering the new paste paths

## Testing
- added targeted unit tests for editor, favorites, menu, and name-favorite paste behavior
- Not run (not requested)