### PR TITLE
add ssl-required support for postgres, mysql, and oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,18 +226,23 @@ Commands:
   help  Print this message or the help of the given subcommand(s)
 
 Options:
-  -M, --mouse <MOUSE_MODE>   Whether to enable mouse event support. If enabled, the default mouse event handling for your terminal
-                             will not work. [possible values: true, false]
-  -u, --url <URL>            Full connection URL for the database, e.g. postgres://username:password@localhost:5432/dbname
-      --username <USERNAME>  Username for database connection
-      --password <PASSWORD>  Password for database connection
-  -R, --reenter-password     Reenter the password for a saved database connection
-      --host <HOST>          Host for database connection (ex. localhost)
-      --port <PORT>          Port for database connection (ex. 5432)
-      --database <DATABASE>  Name of database for connection (ex. postgres)
-      --driver <DRIVER>      Driver for database connection (ex. postgres)
-  -h, --help                 Print help
-  -V, --version              Print version
+  -M, --mouse <MOUSE_MODE>       Whether to enable mouse event support. If enabled, your terminal's
+                                 default mouse event handling will not work. [possible values: true,
+                                 false]
+  -u, --url <URL>                Full connection URL for the database, e.g.
+                                 postgres://username:password@localhost:5432/dbname
+      --username <USERNAME>      Username for database connection
+      --password <PASSWORD>      Password for database connection
+  -R, --reenter-password         Reenter the password for a saved database connection
+      --host <HOST>              Host for database connection (ex. localhost)
+      --port <PORT>              Port for database connection (ex. 5432)
+      --database <DATABASE>      Name of database for connection (ex. postgres)
+      --driver <DRIVER>          Driver for database connection (ex. postgres)
+      --enable-cleartext-plugin  Enable MySQL cleartext plugin
+      --ssl-required             Require an SSL/TLS connection (supported by PostgreSQL, MySQL, and
+                                 Oracle)
+  -h, --help                     Print help
+  -V, --version                  Print version
 ```
 
 <!-- TOC --><a name="with-connection-options"></a>
@@ -253,7 +258,8 @@ rainfrog \
   --username <username> \
   --host <hostname> \
   --port <db_port> \
-  --database <db_name>
+  --database <db_name> \
+  --ssl-required
 ```
 
 <!-- TOC --><a name="with-connection-url"></a>
@@ -264,8 +270,14 @@ to the database (ex. `postgres://username:password@localhost:5432/postgres`).
 it will take precedence over all connection options.
 
 ```sh
-rainfrog --url $(connection_url)
+rainfrog --url $(connection_url) --ssl-required
 ```
+
+`--ssl-required` overrides the transport setting from a connection URL. It selects
+PostgreSQL's `require` mode, MySQL's `required` mode, or Oracle's `tcps` protocol.
+SQLite and DuckDB do not support SSL/TLS connections. Advanced certificate and
+verification settings can still be supplied in PostgreSQL and MySQL URL parameters,
+or through an Oracle Easy Connect string and Oracle client configuration.
 
 <!-- TOC --><a name="with-environment-variables"></a>
 ### with environment variables

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,6 +75,13 @@ pub struct Cli {
   )]
   pub enable_cleartext_plugin: bool,
 
+  #[arg(
+    long = "ssl-required",
+    action = clap::ArgAction::SetTrue,
+    help = "Require an SSL/TLS connection (supported by PostgreSQL, MySQL, and Oracle)"
+  )]
+  pub ssl_required: bool,
+
   #[arg(skip)]
   pub connection_name: Option<String>,
 }
@@ -333,5 +340,17 @@ mod tests {
   fn reenter_password_short_flag_sets_true() {
     let cli = Cli::parse_from(["rainfrog", "-R"]);
     assert!(cli.reenter_password);
+  }
+
+  #[test]
+  fn ssl_required_defaults_to_false() {
+    let cli = Cli::parse_from(["rainfrog"]);
+    assert!(!cli.ssl_required);
+  }
+
+  #[test]
+  fn ssl_required_flag_sets_true() {
+    let cli = Cli::parse_from(["rainfrog", "--ssl-required"]);
+    assert!(cli.ssl_required);
   }
 }

--- a/src/database/mysql.rs
+++ b/src/database/mysql.rs
@@ -490,7 +490,14 @@ impl MySqlDriver {
       },
     };
 
-    Ok(if ssl_required { opts.ssl_mode(MySqlSslMode::Required) } else { opts })
+    Ok(if ssl_required {
+      match opts.get_ssl_mode() {
+        MySqlSslMode::VerifyCa | MySqlSslMode::VerifyIdentity => opts,
+        _ => opts.ssl_mode(MySqlSslMode::Required),
+      }
+    } else {
+      opts
+    })
   }
 }
 
@@ -794,6 +801,29 @@ mod tests {
     ]);
     let opts = MySqlDriver::build_connection_opts(args).unwrap();
     assert!(matches!(opts.get_ssl_mode(), MySqlSslMode::Required));
+  }
+
+  #[test]
+  fn ssl_required_preserves_stricter_url_ssl_modes() {
+    for (mode, expected) in
+      [("verify_ca", MySqlSslMode::VerifyCa), ("verify_identity", MySqlSslMode::VerifyIdentity)]
+    {
+      let args = crate::cli::Cli::parse_from([
+        "rainfrog",
+        "--url",
+        &format!("mysql://localhost/mysql?sslmode={mode}"),
+        "--ssl-required",
+      ]);
+      let opts = MySqlDriver::build_connection_opts(args).unwrap();
+      assert!(
+        matches!(
+          (opts.get_ssl_mode(), expected),
+          (MySqlSslMode::VerifyCa, MySqlSslMode::VerifyCa)
+            | (MySqlSslMode::VerifyIdentity, MySqlSslMode::VerifyIdentity)
+        ),
+        "mode {mode} was not preserved"
+      );
+    }
   }
 
   #[test]

--- a/src/database/mysql.rs
+++ b/src/database/mysql.rs
@@ -12,7 +12,7 @@ use futures::stream::StreamExt;
 use sqlparser::ast::Statement;
 use sqlx::{
   Column, Either, MySqlConnection, Row, ValueRef,
-  mysql::{MySql, MySqlConnectOptions, MySqlPoolOptions},
+  mysql::{MySql, MySqlConnectOptions, MySqlPoolOptions, MySqlSslMode},
   pool::PoolConnection,
 };
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -400,13 +400,14 @@ impl MySqlDriver {
   fn build_connection_opts(
     args: crate::cli::Cli,
   ) -> Result<<<sqlx::MySql as sqlx::Database>::Connection as sqlx::Connection>::Options> {
-    match args.connection_url {
+    let ssl_required = args.ssl_required;
+    let opts = match args.connection_url {
       Some(url) => {
         let mut opts = MySqlConnectOptions::from_str(url.trim().trim_start_matches("jdbc:"))?;
         if args.enable_cleartext_plugin {
           opts = opts.enable_cleartext_plugin(true);
         }
-        Ok(opts)
+        opts
       },
       None => {
         let mut opts = MySqlConnectOptions::new();
@@ -485,9 +486,11 @@ impl MySqlDriver {
           opts = opts.enable_cleartext_plugin(true);
         }
 
-        Ok(opts)
+        opts
       },
-    }
+    };
+
+    Ok(if ssl_required { opts.ssl_mode(MySqlSslMode::Required) } else { opts })
   }
 }
 
@@ -774,10 +777,46 @@ fn parse_value(
 
 #[cfg(test)]
 mod tests {
+  use clap::Parser;
   use sqlparser::{ast::Statement, dialect::MySqlDialect, parser::ParserError};
+  use sqlx::mysql::MySqlSslMode;
 
   use super::*;
   use crate::database::{ExecutionType, ParseError, get_execution_type, get_first_query};
+
+  #[test]
+  fn ssl_required_overrides_url_ssl_mode() {
+    let args = crate::cli::Cli::parse_from([
+      "rainfrog",
+      "--url",
+      "mysql://localhost/mysql?sslmode=disabled",
+      "--ssl-required",
+    ]);
+    let opts = MySqlDriver::build_connection_opts(args).unwrap();
+    assert!(matches!(opts.get_ssl_mode(), MySqlSslMode::Required));
+  }
+
+  #[test]
+  fn ssl_required_applies_to_structured_options() {
+    let args = crate::cli::Cli::parse_from([
+      "rainfrog",
+      "--driver",
+      "mysql",
+      "--username",
+      "user",
+      "--password",
+      "password",
+      "--host",
+      "localhost",
+      "--port",
+      "3306",
+      "--database",
+      "mysql",
+      "--ssl-required",
+    ]);
+    let opts = MySqlDriver::build_connection_opts(args).unwrap();
+    assert!(matches!(opts.get_ssl_mode(), MySqlSslMode::Required));
+  }
 
   #[test]
   fn test_get_first_query() {

--- a/src/database/oracle/connect_options.rs
+++ b/src/database/oracle/connect_options.rs
@@ -5,12 +5,19 @@ use std::{
 
 use color_eyre::eyre::Result;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OracleProtocol {
+  Tcp,
+  Tcps,
+}
+
 pub struct OracleConnectOptions {
   user: Option<String>,
   password: Option<String>,
   host: String,
   port: Option<u16>,
   database: String,
+  protocol: OracleProtocol,
 }
 impl OracleConnectOptions {
   fn new() -> Self {
@@ -20,12 +27,16 @@ impl OracleConnectOptions {
       host: "localhost".to_string(),
       port: Some(1521),
       database: "XE".to_string(),
+      protocol: OracleProtocol::Tcp,
     }
   }
 
   fn get_connection_string(&self) -> String {
     let port = self.port.unwrap_or(1521u16);
-    format!("//{}:{}/{}", self.host, port, self.database)
+    match self.protocol {
+      OracleProtocol::Tcp => format!("//{}:{}/{}", self.host, port, self.database),
+      OracleProtocol::Tcps => format!("tcps://{}:{}/{}", self.host, port, self.database),
+    }
   }
   pub fn get_connection_options(
     &self,
@@ -51,6 +62,10 @@ impl OracleConnectOptions {
       Some(url) => {
         let mut opts =
           OracleConnectOptions::from_str(&url).map_err(|e| color_eyre::eyre::eyre!(e))?;
+
+        if args.ssl_required {
+          opts.protocol = OracleProtocol::Tcps;
+        }
 
         // Username
         if opts.user.is_none() {
@@ -89,6 +104,10 @@ impl OracleConnectOptions {
       },
       None => {
         let mut opts = OracleConnectOptions::new();
+
+        if args.ssl_required {
+          opts.protocol = OracleProtocol::Tcps;
+        }
 
         // Username
         if let Some(user) = args.user {
@@ -172,17 +191,16 @@ impl FromStr for OracleConnectOptions {
 
   fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
     let s = s.trim().trim_start_matches("jdbc:oracle:thin:").trim_start_matches("jdbc:");
-    let (is_easy_connect, (auth_part, host_part)) = if s.contains("@//") {
-      (
-        true,
-        s.split_once("@//")
-          .ok_or("Invalid Oracle Easy Connect connection string format".to_string())?,
-      )
-    } else if s.contains("@") {
-      (false, s.split_once('@').ok_or("Invalid Oracle SID connection string format".to_string())?)
-    } else {
-      return Err("Invalid Oracle connection string format".to_string());
-    };
+    let (auth_part, connect_identifier) =
+      s.split_once('@').ok_or("Invalid Oracle connection string format".to_string())?;
+    let (protocol, is_easy_connect, host_part) =
+      if let Some(host_part) = connect_identifier.strip_prefix("tcps://") {
+        (OracleProtocol::Tcps, true, host_part)
+      } else if let Some(host_part) = connect_identifier.strip_prefix("//") {
+        (OracleProtocol::Tcp, true, host_part)
+      } else {
+        (OracleProtocol::Tcp, false, connect_identifier)
+      };
 
     let (user, password) = if auth_part.contains('/') {
       let (user, password) =
@@ -222,7 +240,7 @@ impl FromStr for OracleConnectOptions {
       }
     };
 
-    Ok(OracleConnectOptions { user, password, host, port, database })
+    Ok(OracleConnectOptions { user, password, host, port, database, protocol })
   }
 }
 
@@ -255,5 +273,35 @@ mod tests {
   fn test_oracle_connect_options_get_connection_string() {
     let opts = OracleConnectOptions::new();
     assert_eq!(opts.get_connection_string(), "//localhost:1521/XE");
+  }
+
+  #[test]
+  fn test_oracle_connect_options_from_tcps_string() {
+    let opts = OracleConnectOptions::from_str(
+      "jdbc:oracle:thin:user/password@tcps://localhost:1521/XE?wallet_location=/tmp/wallet",
+    )
+    .unwrap();
+    assert_eq!(opts.protocol, OracleProtocol::Tcps);
+    assert_eq!(
+      opts.get_connection_string(),
+      "tcps://localhost:1521/XE?wallet_location=/tmp/wallet"
+    );
+  }
+
+  #[test]
+  fn ssl_required_uses_tcps_and_preserves_parameters() {
+    use clap::Parser;
+
+    let args = crate::cli::Cli::parse_from([
+      "rainfrog",
+      "--url",
+      "jdbc:oracle:thin:user/password@//localhost:1521/XE?wallet_location=/tmp/wallet",
+      "--ssl-required",
+    ]);
+    let opts = OracleConnectOptions::build_connection_opts(args).unwrap();
+    assert_eq!(
+      opts.get_connection_string(),
+      "tcps://localhost:1521/XE?wallet_location=/tmp/wallet"
+    );
   }
 }

--- a/src/database/oracle/connect_options.rs
+++ b/src/database/oracle/connect_options.rs
@@ -191,15 +191,20 @@ impl FromStr for OracleConnectOptions {
 
   fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
     let s = s.trim().trim_start_matches("jdbc:oracle:thin:").trim_start_matches("jdbc:");
-    let (auth_part, connect_identifier) =
-      s.split_once('@').ok_or("Invalid Oracle connection string format".to_string())?;
-    let (protocol, is_easy_connect, host_part) =
-      if let Some(host_part) = connect_identifier.strip_prefix("tcps://") {
-        (OracleProtocol::Tcps, true, host_part)
-      } else if let Some(host_part) = connect_identifier.strip_prefix("//") {
-        (OracleProtocol::Tcp, true, host_part)
+    let easy_connect_separator = [("@//", OracleProtocol::Tcp), ("@tcps://", OracleProtocol::Tcps)]
+      .into_iter()
+      .filter_map(|(separator, protocol)| {
+        s.rfind(separator).map(|index| (index, separator, protocol))
+      })
+      .max_by_key(|(index, _, _)| *index);
+
+    let (auth_part, protocol, is_easy_connect, host_part) =
+      if let Some((index, separator, protocol)) = easy_connect_separator {
+        (&s[..index], protocol, true, &s[index + separator.len()..])
       } else {
-        (OracleProtocol::Tcp, false, connect_identifier)
+        let (auth_part, host_part) =
+          s.rsplit_once('@').ok_or("Invalid Oracle connection string format".to_string())?;
+        (auth_part, OracleProtocol::Tcp, false, host_part)
       };
 
     let (user, password) = if auth_part.contains('/') {
@@ -250,9 +255,9 @@ mod tests {
   #[test]
   fn test_oracle_connect_options_from_easy_connect_string() {
     let opts =
-      OracleConnectOptions::from_str("jdbc:oracle:thin:user/password@//localhost:1521/XE").unwrap();
+      OracleConnectOptions::from_str("jdbc:oracle:thin:user/p@ss@//localhost:1521/XE").unwrap();
     assert_eq!(opts.user, Some("user".to_string()));
-    assert_eq!(opts.password, Some("password".to_string()));
+    assert_eq!(opts.password, Some("p@ss".to_string()));
     assert_eq!(opts.host, "localhost");
     assert_eq!(opts.port, Some(1521));
     assert_eq!(opts.database, "XE");
@@ -261,9 +266,9 @@ mod tests {
   #[test]
   fn test_oracle_connect_options_from_sid_string() {
     let opts =
-      OracleConnectOptions::from_str("jdbc:oracle:thin:user/password@localhost:1521:XE").unwrap();
+      OracleConnectOptions::from_str("jdbc:oracle:thin:user/p@ss@localhost:1521:XE").unwrap();
     assert_eq!(opts.user, Some("user".to_string()));
-    assert_eq!(opts.password, Some("password".to_string()));
+    assert_eq!(opts.password, Some("p@ss".to_string()));
     assert_eq!(opts.host, "localhost");
     assert_eq!(opts.port, Some(1521));
     assert_eq!(opts.database, "XE");
@@ -278,9 +283,10 @@ mod tests {
   #[test]
   fn test_oracle_connect_options_from_tcps_string() {
     let opts = OracleConnectOptions::from_str(
-      "jdbc:oracle:thin:user/password@tcps://localhost:1521/XE?wallet_location=/tmp/wallet",
+      "jdbc:oracle:thin:user/p@ss@tcps://localhost:1521/XE?wallet_location=/tmp/wallet",
     )
     .unwrap();
+    assert_eq!(opts.password, Some("p@ss".to_string()));
     assert_eq!(opts.protocol, OracleProtocol::Tcps);
     assert_eq!(
       opts.get_connection_string(),

--- a/src/database/postgresql.rs
+++ b/src/database/postgresql.rs
@@ -13,7 +13,7 @@ use sqlparser::ast::Statement;
 use sqlx::{
   Column, Either, Row, ValueRef,
   pool::PoolConnection,
-  postgres::{PgConnectOptions, PgConnection, PgPoolOptions, Postgres},
+  postgres::{PgConnectOptions, PgConnection, PgPoolOptions, PgSslMode, Postgres},
   types::Uuid,
 };
 use tokio::sync::Mutex;
@@ -411,8 +411,9 @@ impl PostgresDriver {
   fn build_connection_opts(
     args: crate::cli::Cli,
   ) -> Result<<<sqlx::Postgres as sqlx::Database>::Connection as sqlx::Connection>::Options> {
-    match args.connection_url {
-      Some(url) => Ok(PgConnectOptions::from_str(url.trim().trim_start_matches("jdbc:"))?),
+    let ssl_required = args.ssl_required;
+    let opts = match args.connection_url {
+      Some(url) => PgConnectOptions::from_str(url.trim().trim_start_matches("jdbc:"))?,
       None => {
         let mut opts = PgConnectOptions::new();
 
@@ -480,9 +481,11 @@ impl PostgresDriver {
           }
         }
 
-        Ok(opts)
+        opts
       },
-    }
+    };
+
+    Ok(if ssl_required { opts.ssl_mode(PgSslMode::Require) } else { opts })
   }
 }
 
@@ -857,10 +860,46 @@ fn parse_value(
 
 #[cfg(test)]
 mod tests {
+  use clap::Parser;
   use sqlparser::{ast::Statement, dialect::PostgreSqlDialect, parser::ParserError};
+  use sqlx::postgres::PgSslMode;
 
   use super::*;
   use crate::database::{ExecutionType, ParseError, get_execution_type, get_first_query};
+
+  #[test]
+  fn ssl_required_overrides_url_ssl_mode() {
+    let args = crate::cli::Cli::parse_from([
+      "rainfrog",
+      "--url",
+      "postgres://localhost/postgres?sslmode=disable",
+      "--ssl-required",
+    ]);
+    let opts = PostgresDriver::build_connection_opts(args).unwrap();
+    assert!(matches!(opts.get_ssl_mode(), PgSslMode::Require));
+  }
+
+  #[test]
+  fn ssl_required_applies_to_structured_options() {
+    let args = crate::cli::Cli::parse_from([
+      "rainfrog",
+      "--driver",
+      "postgres",
+      "--username",
+      "user",
+      "--password",
+      "password",
+      "--host",
+      "localhost",
+      "--port",
+      "5432",
+      "--database",
+      "postgres",
+      "--ssl-required",
+    ]);
+    let opts = PostgresDriver::build_connection_opts(args).unwrap();
+    assert!(matches!(opts.get_ssl_mode(), PgSslMode::Require));
+  }
 
   #[test]
   fn test_get_first_query() {

--- a/src/database/postgresql.rs
+++ b/src/database/postgresql.rs
@@ -485,7 +485,14 @@ impl PostgresDriver {
       },
     };
 
-    Ok(if ssl_required { opts.ssl_mode(PgSslMode::Require) } else { opts })
+    Ok(if ssl_required {
+      match opts.get_ssl_mode() {
+        PgSslMode::VerifyCa | PgSslMode::VerifyFull => opts,
+        _ => opts.ssl_mode(PgSslMode::Require),
+      }
+    } else {
+      opts
+    })
   }
 }
 
@@ -877,6 +884,29 @@ mod tests {
     ]);
     let opts = PostgresDriver::build_connection_opts(args).unwrap();
     assert!(matches!(opts.get_ssl_mode(), PgSslMode::Require));
+  }
+
+  #[test]
+  fn ssl_required_preserves_stricter_url_ssl_modes() {
+    for (mode, expected) in
+      [("verify-ca", PgSslMode::VerifyCa), ("verify-full", PgSslMode::VerifyFull)]
+    {
+      let args = crate::cli::Cli::parse_from([
+        "rainfrog",
+        "--url",
+        &format!("postgres://localhost/postgres?sslmode={mode}"),
+        "--ssl-required",
+      ]);
+      let opts = PostgresDriver::build_connection_opts(args).unwrap();
+      assert!(
+        matches!(
+          (opts.get_ssl_mode(), expected),
+          (PgSslMode::VerifyCa, PgSslMode::VerifyCa)
+            | (PgSslMode::VerifyFull, PgSslMode::VerifyFull)
+        ),
+        "mode {mode} was not preserved"
+      );
+    }
   }
 
   #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,10 @@ async fn run_app(mut args: Cli, config: Config, driver: Driver) -> Result<()> {
   Ok(())
 }
 
+fn supports_ssl_required(driver: Driver) -> bool {
+  matches!(driver, Driver::Postgres | Driver::MySql | Driver::Oracle)
+}
+
 fn resolve_driver(args: &mut Cli, config: &Config) -> Result<Driver> {
   let url = args.connection_url.clone().or_else(|| {
     env::var("DATABASE_URL").map_or(None, |url| {
@@ -165,6 +169,11 @@ async fn tokio_main() -> Result<()> {
         "warning: --enable-cleartext-plugin is only supported for mysql connections and will be ignored"
       );
     }
+    if args.ssl_required && !supports_ssl_required(driver) {
+      eprintln!(
+        "warning: --ssl-required is only supported for postgres, mysql, and oracle connections and will be ignored"
+      );
+    }
 
     run_app(args, config, driver).await
   }
@@ -189,4 +198,19 @@ pub fn prompt_for_driver() -> Result<Driver> {
   io::stdout().flush()?;
   io::stdin().read_line(&mut driver)?;
   driver.trim().to_lowercase().parse()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn ssl_required_support_matches_tls_capable_drivers() {
+    assert!(supports_ssl_required(Driver::Postgres));
+    assert!(supports_ssl_required(Driver::MySql));
+    assert!(supports_ssl_required(Driver::Oracle));
+    assert!(!supports_ssl_required(Driver::Sqlite));
+    #[cfg(feature = "duckdb")]
+    assert!(!supports_ssl_required(Driver::DuckDb));
+  }
 }


### PR DESCRIPTION
closes #292 

## Summary
- add a new `--ssl-required` flag to request tls/ssl connections
- apply the flag to postgres, mysql, and oracle connection setup
- warn when the flag is used with unsupported drivers
- update the README with usage notes and connection examples
- add tests for cli parsing and driver-specific ssl behavior

## Testing
- Not run (not requested)