### PR TITLE
feat: add external editor for query editing

### DIFF
--- a/.config/rainfrog_config.toml
+++ b/.config/rainfrog_config.toml
@@ -33,6 +33,7 @@ autopairs_enabled = true
 "<Ctrl-space>" = "TriggerCompletion"
 "<Alt-q>" = "AbortQuery"
 "<Alt-e>" = "RequestExternalEditor"
+"<F6>" = "RequestExternalEditor"
 "<F5>" = "SubmitEditorQuery"
 "<F7>" = "SubmitEditorQueryBypassParser"
 "<Alt-1>" = "FocusMenu"

--- a/.config/rainfrog_config.toml
+++ b/.config/rainfrog_config.toml
@@ -32,6 +32,7 @@ autopairs_enabled = true
 [keybindings.Editor]
 "<Ctrl-space>" = "TriggerCompletion"
 "<Alt-q>" = "AbortQuery"
+"<Alt-e>" = "RequestExternalEditor"
 "<F5>" = "SubmitEditorQuery"
 "<F7>" = "SubmitEditorQueryBypassParser"
 "<Alt-1>" = "FocusMenu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3381,6 +3381,7 @@ dependencies = [
  "sqlx",
  "strip-ansi-escapes",
  "strum 0.27.2",
+ "tempfile",
  "tokio",
  "tokio-util",
  "toml 0.8.23",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ sqlx = { version = "0.8.6", features = [
 ] }
 strip-ansi-escapes = "0.2.0"
 strum = { version = "0.27.1", features = ["derive"] }
+tempfile = "3.21.0"
 tokio = { version = "1.43.1", features = ["full"] }
 tokio-util = "0.7.9"
 toml = "0.8.19"

--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ Vim keybindings in rainfrog can be found at [vim.rs](./src/vim.rs).
 | Keybinding        | Description                            |
 | ----------------- | -------------------------------------- |
 | `Alt+Enter`, `F5` | Execute query                          |
+| `Alt+e`           | Edit query in external editor          |
 | `F7`              | Bypass parser to execute query (cannot rollback, no validation) |
 | `Ctrl+Space`      | Show SQL, schema, buffer, or path completions |
 | `Tab`, `Enter`    | Accept the selected completion             |

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ Vim keybindings in rainfrog can be found at [vim.rs](./src/vim.rs).
 | Keybinding        | Description                            |
 | ----------------- | -------------------------------------- |
 | `Alt+Enter`, `F5` | Execute query                          |
-| `Alt+e`           | Edit query in external editor          |
+| `Alt+e`, `F6`     | Edit query in external editor          |
 | `F7`              | Bypass parser to execute query (cannot rollback, no validation) |
 | `Ctrl+Space`      | Show SQL, schema, buffer, or path completions |
 | `Tab`, `Enter`    | Accept the selected completion             |

--- a/src/action.rs
+++ b/src/action.rs
@@ -43,6 +43,8 @@ pub enum Action {
   SubmitEditorQuery,
   SubmitEditorQueryBypassParser,
   TriggerCompletion,
+  RequestExternalEditor,
+  EditQueryExternally(Vec<String>),
   Query(Vec<String>, bool, bool), // (query_lines, execution_confirmed, bypass_parser)
   MenuPreview(MenuPreview, MenuTarget), // (preview, target)
   QueryToEditor(Vec<String>),

--- a/src/app.rs
+++ b/src/app.rs
@@ -743,7 +743,7 @@ impl App {
         Focus::Menu =>
           "[R] refresh [j|↓] down [k|↑] up [l|<enter>] table list [h|󰁮 ] schema list [y] copy name [/] search [g] top [G] bottom",
         Focus::Editor if !self.state.query_task_running =>
-          "[<alt + enter>|<f5>] execute query [<alt + e>] external editor [<ctrl + f>|<alt + f>] save query to favorites",
+          "[<alt + enter>|<f5>] execute query [<alt + e>|<f6>] external editor [<ctrl + f>|<alt + f>] save query to favorites",
         Focus::History => "[j|↓] down [k|↑] up [y] copy query [I] edit query [D] clear history",
         Focus::Favorites =>
           "[j|↓] down [k|↑] up [y] copy query [I] edit query [D] delete entry [/] search [<esc>] clear search",

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,6 +28,7 @@ use crate::{
   },
   config::Config,
   database::{self, Database, DbTaskResult, ExecutionType, Rows},
+  external_editor,
   focus::Focus,
   popups::{
     PopUp, PopUpPayload, confirm_bypass::ConfirmBypass, confirm_export::ConfirmExport,
@@ -441,6 +442,25 @@ impl App {
           Action::LoadMenu => {
             self.completion.start_menu_load(database.as_ref())?;
           },
+          Action::EditQueryExternally(lines) => {
+            let query = lines.join("\n");
+            tui.exit()?;
+            let edit_result = external_editor::edit_query(&query);
+            let resume_result = tui.enter();
+            resume_result?;
+
+            match edit_result {
+              Ok(edited) => {
+                action_tx.send(Action::QueryToEditor(external_editor::query_lines(&edited)))?;
+              },
+              Err(error) => {
+                self.set_data_state(
+                  Some(Err(error.wrap_err("Failed to edit query externally"))),
+                  None,
+                );
+              },
+            }
+          },
           Action::Query(query_lines, confirmed, bypass) => 'query_action: {
             if self.state.query_task_running {
               break 'query_action;
@@ -723,7 +743,7 @@ impl App {
         Focus::Menu =>
           "[R] refresh [j|↓] down [k|↑] up [l|<enter>] table list [h|󰁮 ] schema list [y] copy name [/] search [g] top [G] bottom",
         Focus::Editor if !self.state.query_task_running =>
-          "[<alt + enter>|<f5>] execute query [<ctrl + f>|<alt + f>] save query to favorites",
+          "[<alt + enter>|<f5>] execute query [<alt + e>] external editor [<ctrl + f>|<alt + f>] save query to favorites",
         Focus::History => "[j|↓] down [k|↑] up [y] copy query [I] edit query [D] clear history",
         Focus::Favorites =>
           "[j|↓] down [k|↑] up [y] copy query [I] edit query [D] delete entry [/] search [<esc>] clear search",

--- a/src/app.rs
+++ b/src/app.rs
@@ -445,7 +445,7 @@ impl App {
           Action::EditQueryExternally(lines) => {
             let query = lines.join("\n");
             tui.exit()?;
-            let edit_result = external_editor::edit_query(&query);
+            let edit_result = external_editor::edit_query(query).await;
             let resume_result = tui.enter();
             resume_result?;
 

--- a/src/components/data.rs
+++ b/src/components/data.rs
@@ -68,6 +68,10 @@ pub struct Data<'a> {
   explain_max_y_offset: u16,
 }
 
+fn error_text(error: &eyre::Report) -> String {
+  format!("{error:#}")
+}
+
 impl Data<'_> {
   pub fn new() -> Self {
     Data {
@@ -488,7 +492,7 @@ impl Component for Data<'_> {
           self.command_tx.clone().unwrap().send(Action::CopyData(text.to_string()))?;
           self.scrollable.transition_selection_mode(Some(SelectionMode::Copied));
         } else if let DataState::Error(err) = &self.data_state {
-          self.command_tx.clone().unwrap().send(Action::CopyData(err.to_string()))?;
+          self.command_tx.clone().unwrap().send(Action::CopyData(error_text(err)))?;
           self.scrollable.transition_selection_mode(Some(SelectionMode::Copied));
         }
       },
@@ -676,7 +680,7 @@ impl Component for Data<'_> {
       },
       DataState::Error(e) => {
         f.render_widget(
-          Paragraph::new(e.to_string())
+          Paragraph::new(error_text(e))
             .style(Style::default().fg(Color::Red))
             .wrap(Wrap { trim: true })
             .block(block),
@@ -793,6 +797,20 @@ impl TableForYank {
         col
       })
       .collect()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn error_text_includes_os_error() {
+    let os_error = std::io::Error::from_raw_os_error(2);
+    let os_message = os_error.to_string();
+    let error = eyre::Report::new(os_error).wrap_err("Failed to launch external editor 'vi'");
+
+    assert_eq!(error_text(&error), format!("Failed to launch external editor 'vi': {os_message}"));
   }
 }
 

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -453,6 +453,14 @@ impl Component for Editor<'_> {
     }
     match action {
       Action::TriggerCompletion => self.request_completion(app_state, true),
+      Action::RequestExternalEditor => {
+        self.completion.dismiss();
+        self.cancel_completion();
+        self.pending_request_snapshot = None;
+        if let Some(sender) = &self.command_tx {
+          sender.send(Action::EditQueryExternally(self.textarea.lines().to_vec()))?;
+        }
+      },
       Action::SubmitEditorQueryBypassParser => {
         if let Some(sender) = &self.command_tx {
           sender.send(Action::Query(self.textarea.lines().to_vec(), false, true))?;
@@ -842,6 +850,21 @@ mod tests {
     assert_eq!(action_rx.try_recv().unwrap(), Action::Query(vec!["sel".into()], false, false));
     assert_eq!(editor.vim_state.mode, Mode::Normal);
     assert!(!editor.completion.is_visible());
+  }
+
+  #[test]
+  fn external_editor_request_forwards_current_query() {
+    let mut editor = Editor::new();
+    editor.textarea = TextArea::from(["select 1;".to_string(), "select 2;".to_string()]);
+    let (action_tx, mut action_rx) = mpsc::unbounded_channel();
+    editor.register_action_handler(action_tx).unwrap();
+
+    editor.update(Action::RequestExternalEditor, &app_state_with_focus(Focus::Editor)).unwrap();
+
+    assert_eq!(
+      action_rx.try_recv().unwrap(),
+      Action::EditQueryExternally(vec!["select 1;".into(), "select 2;".into()])
+    );
   }
 
   #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -611,6 +611,14 @@ mod tests {
         .unwrap(),
       &Action::RequestExternalEditor
     );
+    assert_eq!(
+      c.keybindings
+        .get(&Focus::Editor)
+        .unwrap()
+        .get(&parse_key_sequence("<F6>").unwrap_or_default())
+        .unwrap(),
+      &Action::RequestExternalEditor
+    );
     assert_eq!(c.settings.mouse_mode, Some(true));
     assert_eq!(c.settings.autocomplete_enabled, Some(true));
     assert_eq!(c.settings.autocomplete_debounce_ms, Some(100));

--- a/src/config.rs
+++ b/src/config.rs
@@ -603,6 +603,14 @@ mod tests {
         .unwrap(),
       &Action::AbortQuery
     );
+    assert_eq!(
+      c.keybindings
+        .get(&Focus::Editor)
+        .unwrap()
+        .get(&parse_key_sequence("<Alt-e>").unwrap_or_default())
+        .unwrap(),
+      &Action::RequestExternalEditor
+    );
     assert_eq!(c.settings.mouse_mode, Some(true));
     assert_eq!(c.settings.autocomplete_enabled, Some(true));
     assert_eq!(c.settings.autocomplete_debounce_ms, Some(100));

--- a/src/external_editor.rs
+++ b/src/external_editor.rs
@@ -1,0 +1,99 @@
+use std::{env, path::Path, process::Command};
+
+use color_eyre::eyre::{Result, WrapErr, bail, eyre};
+
+#[derive(Debug, PartialEq, Eq)]
+struct EditorCommand {
+  program: String,
+  args: Vec<String>,
+}
+
+fn editor_command_with(lookup: &impl Fn(&str) -> Option<String>) -> Result<EditorCommand> {
+  let editor = lookup("VISUAL")
+    .filter(|value| !value.trim().is_empty())
+    .or_else(|| lookup("EDITOR").filter(|value| !value.trim().is_empty()))
+    .unwrap_or_else(|| "vi".to_string());
+  let mut parts = editor.split_whitespace();
+  let program = parts.next().ok_or_else(|| eyre!("Could not parse editor command"))?.to_string();
+  let args = parts.map(str::to_string).collect();
+  Ok(EditorCommand { program, args })
+}
+
+pub fn open_editor(path: &Path) -> Result<()> {
+  let command = editor_command_with(&|name| env::var(name).ok())?;
+  run_editor(&command, path)
+}
+
+fn run_editor(command: &EditorCommand, path: &Path) -> Result<()> {
+  let status = Command::new(&command.program)
+    .args(&command.args)
+    .arg(path)
+    .status()
+    .wrap_err_with(|| format!("Failed to launch external editor '{}'", command.program))?;
+  if !status.success() {
+    bail!("External editor '{}' exited with {status}", command.program);
+  }
+  Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn env_lookup<'a>(values: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+    move |name| values.iter().find_map(|(key, value)| (*key == name).then(|| value.to_string()))
+  }
+
+  #[test]
+  fn visual_takes_precedence_over_editor() {
+    let command =
+      editor_command_with(&env_lookup(&[("VISUAL", "nvim"), ("EDITOR", "vim")])).unwrap();
+
+    assert_eq!(command.program, "nvim");
+    assert!(command.args.is_empty());
+  }
+
+  #[test]
+  fn empty_editor_variables_are_ignored() {
+    let command =
+      editor_command_with(&env_lookup(&[("VISUAL", "  "), ("EDITOR", "vim -f")])).unwrap();
+
+    assert_eq!(command.program, "vim");
+    assert_eq!(command.args, ["-f"]);
+  }
+
+  #[test]
+  fn vi_is_used_when_editor_variables_are_missing() {
+    let command = editor_command_with(&env_lookup(&[])).unwrap();
+
+    assert_eq!(command.program, "vi");
+    assert!(command.args.is_empty());
+  }
+
+  #[test]
+  fn editor_command_supports_simple_arguments() {
+    let command = editor_command_with(&env_lookup(&[("VISUAL", "code --wait")])).unwrap();
+
+    assert_eq!(command.program, "code");
+    assert_eq!(command.args, ["--wait"]);
+  }
+
+  #[test]
+  fn launch_error_preserves_os_error() {
+    let missing_editor = env::temp_dir().join(format!(
+      "rainfrog-missing-editor-{}-{}",
+      std::process::id(),
+      std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
+    ));
+    let command =
+      EditorCommand { program: missing_editor.to_string_lossy().into_owned(), args: Vec::new() };
+
+    let error = run_editor(&command, Path::new("query.sql")).unwrap_err();
+
+    assert_eq!(
+      error.downcast_ref::<std::io::Error>().map(std::io::Error::kind),
+      Some(std::io::ErrorKind::NotFound)
+    );
+    assert!(format!("{error:#}").contains(&command.program));
+  }
+}

--- a/src/external_editor.rs
+++ b/src/external_editor.rs
@@ -1,4 +1,4 @@
-use std::{env, path::Path, process::Command};
+use std::{env, fs, io::Write, path::Path, process::Command};
 
 use color_eyre::eyre::{Result, WrapErr, bail, eyre};
 
@@ -34,6 +34,30 @@ fn run_editor(command: &EditorCommand, path: &Path) -> Result<()> {
     bail!("External editor '{}' exited with {status}", command.program);
   }
   Ok(())
+}
+
+pub fn edit_query(query: &str) -> Result<String> {
+  edit_query_with(query, open_editor)
+}
+
+fn edit_query_with<F>(query: &str, launch: F) -> Result<String>
+where
+  F: FnOnce(&Path) -> Result<()>,
+{
+  let mut file = tempfile::Builder::new()
+    .prefix("rainfrog-query-")
+    .suffix(".sql")
+    .tempfile()
+    .wrap_err("Failed to create temporary query file")?;
+  file.write_all(query.as_bytes()).wrap_err("Failed to write query to temporary file")?;
+  file.flush().wrap_err("Failed to flush query to temporary file")?;
+  launch(file.path())?;
+  fs::read_to_string(file.path()).wrap_err("Failed to read query from temporary file")
+}
+
+pub fn query_lines(text: &str) -> Vec<String> {
+  let lines = text.lines().map(str::to_string).collect::<Vec<_>>();
+  if lines.is_empty() { vec![String::new()] } else { lines }
 }
 
 #[cfg(test)]
@@ -76,6 +100,44 @@ mod tests {
 
     assert_eq!(command.program, "code");
     assert_eq!(command.args, ["--wait"]);
+  }
+
+  #[test]
+  fn empty_query_stays_as_one_editor_line() {
+    assert_eq!(query_lines(""), [""]);
+  }
+
+  #[test]
+  fn multiline_query_is_split_into_editor_lines() {
+    assert_eq!(query_lines("select 1;\n\nselect 2;\n"), ["select 1;", "", "select 2;"]);
+  }
+
+  #[test]
+  fn edit_query_round_trips_sql_through_a_temporary_file() {
+    let edited = edit_query_with("select 1;", |path| {
+      assert_eq!(path.extension().and_then(|value| value.to_str()), Some("sql"));
+      assert_eq!(fs::read_to_string(path)?, "select 1;");
+      fs::write(path, "select * from robot;")?;
+      Ok(())
+    })
+    .unwrap();
+
+    assert_eq!(edited, "select * from robot;");
+  }
+
+  #[test]
+  fn read_error_identifies_the_temporary_file_operation() {
+    let error = edit_query_with("select 1;", |path| {
+      fs::write(path, [0xff])?;
+      Ok(())
+    })
+    .unwrap_err();
+
+    assert_eq!(
+      error.downcast_ref::<std::io::Error>().map(std::io::Error::kind),
+      Some(std::io::ErrorKind::InvalidData)
+    );
+    assert!(format!("{error:#}").starts_with("Failed to read query from temporary file: "));
   }
 
   #[test]

--- a/src/external_editor.rs
+++ b/src/external_editor.rs
@@ -36,23 +36,27 @@ fn run_editor(command: &EditorCommand, path: &Path) -> Result<()> {
   Ok(())
 }
 
-pub fn edit_query(query: &str) -> Result<String> {
-  edit_query_with(query, open_editor)
+pub async fn edit_query(query: String) -> Result<String> {
+  edit_query_with(query, open_editor).await
 }
 
-fn edit_query_with<F>(query: &str, launch: F) -> Result<String>
+async fn edit_query_with<F>(query: String, launch: F) -> Result<String>
 where
-  F: FnOnce(&Path) -> Result<()>,
+  F: FnOnce(&Path) -> Result<()> + Send + 'static,
 {
-  let mut file = tempfile::Builder::new()
-    .prefix("rainfrog-query-")
-    .suffix(".sql")
-    .tempfile()
-    .wrap_err("Failed to create temporary query file")?;
-  file.write_all(query.as_bytes()).wrap_err("Failed to write query to temporary file")?;
-  file.flush().wrap_err("Failed to flush query to temporary file")?;
-  launch(file.path())?;
-  fs::read_to_string(file.path()).wrap_err("Failed to read query from temporary file")
+  tokio::task::spawn_blocking(move || {
+    let mut file = tempfile::Builder::new()
+      .prefix("rainfrog-query-")
+      .suffix(".sql")
+      .tempfile()
+      .wrap_err("Failed to create temporary query file")?;
+    file.write_all(query.as_bytes()).wrap_err("Failed to write query to temporary file")?;
+    file.flush().wrap_err("Failed to flush query to temporary file")?;
+    launch(file.path())?;
+    fs::read_to_string(file.path()).wrap_err("Failed to read query from temporary file")
+  })
+  .await
+  .wrap_err("External editor task failed")?
 }
 
 pub fn query_lines(text: &str) -> Vec<String> {
@@ -112,25 +116,50 @@ mod tests {
     assert_eq!(query_lines("select 1;\n\nselect 2;\n"), ["select 1;", "", "select 2;"]);
   }
 
-  #[test]
-  fn edit_query_round_trips_sql_through_a_temporary_file() {
-    let edited = edit_query_with("select 1;", |path| {
+  #[tokio::test]
+  async fn edit_query_round_trips_sql_through_a_temporary_file() {
+    let edited = edit_query_with("select 1;".to_string(), |path| {
       assert_eq!(path.extension().and_then(|value| value.to_str()), Some("sql"));
       assert_eq!(fs::read_to_string(path)?, "select 1;");
       fs::write(path, "select * from robot;")?;
       Ok(())
     })
+    .await
     .unwrap();
 
     assert_eq!(edited, "select * from robot;");
   }
 
-  #[test]
-  fn read_error_identifies_the_temporary_file_operation() {
-    let error = edit_query_with("select 1;", |path| {
+  #[tokio::test(flavor = "current_thread")]
+  async fn editing_query_keeps_async_runtime_responsive() {
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+
+    let edit = edit_query_with("select 1;".to_string(), move |path| {
+      started_tx.send(()).unwrap();
+      release_rx
+        .recv_timeout(std::time::Duration::from_secs(1))
+        .wrap_err("Async runtime did not progress while the editor was open")?;
+      fs::write(path, "select * from robot;")?;
+      Ok(())
+    });
+    let release_editor = async move {
+      started_rx.await.unwrap();
+      release_tx.send(()).unwrap();
+    };
+
+    let (edited, ()) = tokio::join!(edit, release_editor);
+
+    assert_eq!(edited.unwrap(), "select * from robot;");
+  }
+
+  #[tokio::test]
+  async fn read_error_identifies_the_temporary_file_operation() {
+    let error = edit_query_with("select 1;".to_string(), |path| {
       fs::write(path, [0xff])?;
       Ok(())
     })
+    .await
     .unwrap_err();
 
     assert_eq!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ pub mod completion;
 pub mod components;
 pub mod config;
 pub mod database;
+pub mod external_editor;
 pub mod focus;
 pub mod keyring;
 pub mod popups;
@@ -21,7 +22,6 @@ use std::{
   env, fs,
   io::{self, Write},
   path::Path,
-  process::Command,
 };
 
 use clap::Parser;
@@ -119,27 +119,10 @@ fn ensure_config_file(path: &Path) -> Result<()> {
   Ok(())
 }
 
-fn open_editor(path: &Path) -> Result<()> {
-  let editor = env::var("VISUAL")
-    .ok()
-    .filter(|value| !value.trim().is_empty())
-    .or_else(|| env::var("EDITOR").ok().filter(|value| !value.trim().is_empty()))
-    .unwrap_or_else(|| "vi".to_string());
-
-  let mut parts = editor.split_whitespace();
-  let program =
-    parts.next().ok_or_else(|| color_eyre::eyre::eyre!("Could not parse editor command"))?;
-  let status = Command::new(program).args(parts).arg(path).status()?;
-  if !status.success() {
-    color_eyre::eyre::bail!("Editor exited with status code {:?}", status.code());
-  }
-  Ok(())
-}
-
 fn edit_config_file() -> Result<()> {
   let config_path = existing_config_path().unwrap_or_else(preferred_config_path);
   ensure_config_file(&config_path)?;
-  open_editor(&config_path)
+  external_editor::open_editor(&config_path)
 }
 
 async fn tokio_main() -> Result<()> {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -28,6 +28,12 @@ pub fn io() -> IO {
 }
 pub type Frame<'a> = ratatui::Frame<'a>;
 
+fn clear_terminal_for_full_redraw<B: ratatui::backend::Backend>(
+  terminal: &mut ratatui::Terminal<B>,
+) -> std::result::Result<(), B::Error> {
+  terminal.clear()
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Event {
   Init,
@@ -202,6 +208,7 @@ impl Tui {
       crossterm::execute!(io(), SetTitle(title))?;
     }
     crossterm::execute!(io(), EnterAlternateScreen, cursor::Hide)?;
+    clear_terminal_for_full_redraw(&mut self.terminal)?;
     if self.mouse {
       crossterm::execute!(io(), EnableMouseCapture)?;
     }
@@ -259,5 +266,28 @@ impl DerefMut for Tui {
 impl Drop for Tui {
   fn drop(&mut self) {
     self.exit().unwrap();
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use ratatui::backend::{Backend as _, ClearType, TestBackend};
+
+  #[test]
+  fn resumed_terminal_redraws_an_unchanged_frame() {
+    let mut terminal = ratatui::Terminal::new(TestBackend::new(8, 1)).unwrap();
+    terminal.draw(|frame| frame.render_widget("rainfrog", frame.area())).unwrap();
+    terminal.backend().assert_buffer_lines(["rainfrog"]);
+
+    // Entering a fresh alternate screen clears the physical display without
+    // changing Ratatui's cached previous frame.
+    terminal.backend_mut().clear_region(ClearType::All).unwrap();
+    terminal.backend().assert_buffer_lines(["        "]);
+
+    clear_terminal_for_full_redraw(&mut terminal).unwrap();
+    terminal.draw(|frame| frame.render_widget("rainfrog", frame.area())).unwrap();
+
+    terminal.backend().assert_buffer_lines(["rainfrog"]);
   }
 }


### PR DESCRIPTION
implementation of feature described in #293

binds Alt+e (and \<F6\>) to open the external editor when editing a query
