### PR TITLE
fix: report an invalid keybinding instead of panicking

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use derive_deref::{Deref, DerefMut};
 use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 use ratatui::style::{Color, Modifier, Style};
-use serde::{Deserialize, de::Deserializer};
+use serde::{Deserialize, de, de::Deserializer};
 
 use crate::{action::Action, cli::Driver, focus::Focus, keyring::Password};
 
@@ -230,11 +230,16 @@ impl<'de> Deserialize<'de> for KeyBindings {
       .map(|(focus, inner_map)| {
         let converted_inner_map = inner_map
           .into_iter()
-          .map(|(key_str, cmd)| (parse_key_sequence(&key_str).unwrap(), cmd))
-          .collect();
-        (focus, converted_inner_map)
+          .map(|(key_str, cmd)| {
+            // a typo in the config file must not abort the process
+            parse_key_sequence(&key_str)
+              .map(|keys| (keys, cmd))
+              .map_err(|e| de::Error::custom(format!("invalid keybinding \"{key_str}\": {e}")))
+          })
+          .collect::<Result<HashMap<_, _>, D::Error>>()?;
+        Ok((focus, converted_inner_map))
       })
-      .collect();
+      .collect::<Result<HashMap<_, _>, D::Error>>()?;
 
     Ok(KeyBindings(keybindings))
   }
@@ -591,6 +596,27 @@ mod tests {
   fn test_parse_color_unknown() {
     let color = parse_color("unknown");
     assert_eq!(color, None);
+  }
+
+  #[test]
+  fn test_invalid_keybinding_is_an_error_not_a_panic() {
+    let toml_src = "[keybindings.Editor]\n\"<bogus-key>\" = \"Quit\"\n";
+    let err = toml::from_str::<Config>(toml_src).unwrap_err();
+    assert!(err.to_string().contains("invalid keybinding \"<bogus-key>\""), "got: {err}");
+  }
+
+  #[test]
+  fn test_valid_keybinding_still_parses() {
+    let toml_src = "[keybindings.Editor]\n\"<Alt-e>\" = \"Quit\"\n";
+    let c: Config = toml::from_str(toml_src).unwrap();
+    assert_eq!(
+      c.keybindings
+        .get(&Focus::Editor)
+        .unwrap()
+        .get(&parse_key_sequence("<Alt-e>").unwrap())
+        .unwrap(),
+      &Action::Quit
+    );
   }
 
   #[test]


### PR DESCRIPTION
## What's broken

A typo in a keybinding config key crashes rainfrog instead of reporting the problem:

```
[keybindings.Editor]
"<bogus-key>" = "Quit"
```

```
The application panicked (crashed).
  called `Result::unwrap()` on an `Err` value: "Unable to parse bogus-key"
in src/config.rs:233
```

`<C-p>` and `<F13>` do the same, so this is an ordinary typo rather than an exotic input. `<Ctrl-Shift-p>`, `<space>` and `<Alt-Enter>` all parse fine.

## The cause

`parse_key_sequence` returns a `Result`, and the `Deserialize` impl for `KeyBindings` unwraps it inside the serde visitor, so the error is thrown away and the process aborts.

## The fix

Propagate it as `de::Error::custom`, so the user gets a message naming the offending key and a clean exit:

```
invalid keybinding "<bogus-key>": Unable to parse bogus-key
```

## Relationship to #227

I found this while looking at #227 and I want to be precise about it, because it is not the same bug.

That issue reports a crash from an empty *action* (`"<Alt-e>" = ""`). I checked, and that case already produces a clean error today, listing the valid variants. What crashes is an invalid *key*, which the issue does not mention.

So this fixes a real panic but does not close 227. That one is asking for `""` to mean "unbind", plus a UI change so an overridden default stops being displayed. Both are behaviour decisions I would rather leave to you.

## Verification

`cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean, and the suite is 155 passed, 0 failed.

Two tests added next to the existing keybinding ones: an invalid key is an error containing the key name, and a valid `<Alt-e>` still parses to its action. Reverting the fix with the tests kept reproduces the panic at `config.rs:233`.

Happy to fold in the unbind semantics if you want them here rather than separately.
