### PR TITLE
fix: don't panic on a short rgb color in the config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -600,7 +600,7 @@ mod tests {
   #[test]
   fn test_parse_color_rgb_malformed_one_digit() {
     let color = parse_color("rgb1");
-    let expected = 16 + 1 * 36;
+    let expected = 16 + 36;
     assert_eq!(color, Some(Color::Indexed(expected)));
   }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -498,9 +498,13 @@ fn parse_color(s: &str) -> Option<Color> {
     let c = 232 + s.trim_start_matches("gray").parse::<u8>().unwrap_or_default();
     Some(Color::Indexed(c))
   } else if s.contains("rgb") {
-    let red = (s.as_bytes()[3] as char).to_digit(10).unwrap_or_default() as u8;
-    let green = (s.as_bytes()[4] as char).to_digit(10).unwrap_or_default() as u8;
-    let blue = (s.as_bytes()[5] as char).to_digit(10).unwrap_or_default() as u8;
+    let bytes = s.as_bytes();
+    let digit_at = |i: usize| -> u8 {
+      bytes.get(i).and_then(|b| (*b as char).to_digit(10)).unwrap_or_default() as u8
+    };
+    let red = digit_at(3);
+    let green = digit_at(4);
+    let blue = digit_at(5);
     let c = 16 + red * 36 + green * 6 + blue;
     Some(Color::Indexed(c))
   } else if s == "bold black" {
@@ -584,6 +588,19 @@ mod tests {
   fn test_parse_color_rgb() {
     let color = parse_color("rgb123");
     let expected = 16 + 36 + 2 * 6 + 3;
+    assert_eq!(color, Some(Color::Indexed(expected)));
+  }
+
+  #[test]
+  fn test_parse_color_rgb_malformed_short() {
+    let color = parse_color("rgb");
+    assert_eq!(color, Some(Color::Indexed(16)));
+  }
+
+  #[test]
+  fn test_parse_color_rgb_malformed_one_digit() {
+    let color = parse_color("rgb1");
+    let expected = 16 + 1 * 36;
     assert_eq!(color, Some(Color::Indexed(expected)));
   }
 


### PR DESCRIPTION
## What's broken

A malformed `rgb` value in a config file panics on startup instead of falling back.

```
thread panicked at src/config.rs:501:
index out of bounds: the len is 3 but the index is 3
```

`parse_color` indexes bytes 3, 4 and 5 assuming a fixed `rgbNNN` layout, with no length check. It reaches the whole TUI because `parse_color` is called from `parse_style`, which is called from `Styles::deserialize`, so a typo in the theme takes the app down before it draws anything.

## The fix

Read the three digits through `bytes.get(i)` so a missing one defaults to 0, which is what the sibling branches already do. `color`, `bright color` and `gray` all zero-fill a malformed number with `unwrap_or_default()` and still return a real colour.

I chose that over returning `None` deliberately: `parse_style` treats `None` as leave this fg or bg unset, so `None` would silently drop the style, while zero-filling keeps `"rgb"` behaving like the other malformed cases in the same function. Say the word if you would rather have `None`.

A well-formed `rgb123` is unaffected.

`parse_color` has no other unchecked indexing. The three `parse::<u8>().unwrap_or_default()` calls cannot panic.

## Verification

Two tests next to the existing `test_parse_color_rgb`: `"rgb"` alone and `"rgb1"`. Both panic against the old code with the index-out-of-bounds above. `cargo test` passes, 155 tests.

Same shape as #325, which I have open: a config value that should degrade gracefully taking the process down instead.
