### PR TITLE
fix: yank all misaligns columns containing non-ASCII values

### DIFF
--- a/src/components/data.rs
+++ b/src/components/data.rs
@@ -7,6 +7,7 @@ use ratatui::{prelude::*, symbols::scrollbar, widgets::*};
 use ratatui_textarea::{Input, Key};
 use sqlparser::ast::Statement;
 use tokio::sync::mpsc::UnboundedSender;
+use unicode_width::UnicodeWidthStr;
 
 use super::{
   Frame,
@@ -765,12 +766,15 @@ impl TableForYank {
   }
 
   fn format_column(col: &mut VecDeque<String>, index: usize, last_index: usize) {
-    let width = col.iter().map(|s| s.len()).max().unwrap_or(1) + 1;
+    let width = col.iter().map(|s| s.width()).max().unwrap_or(1) + 1;
 
     let format_cell = |s: &str| {
       let prefix = if index == 0 { "" } else { "| " };
-      let padding =
-        if index == last_index { " ".repeat(0) } else { " ".repeat(width.saturating_sub(s.len())) };
+      let padding = if index == last_index {
+        " ".repeat(0)
+      } else {
+        " ".repeat(width.saturating_sub(s.width()))
+      };
       format!("{prefix}{s}{padding}")
     };
 
@@ -849,6 +853,35 @@ mod yank {
     ];
 
     assert_eq!(expected, result)
+  }
+
+  #[test]
+  fn yank_aligns_columns_by_display_width() {
+    let headers = vec!["id".to_string(), "name".to_string(), "age".to_string()];
+    let rows = vec![
+      vec!["1".to_string(), "café".to_string(), "30".to_string()],
+      vec!["2".to_string(), "abcd".to_string(), "40".to_string()],
+      vec!["3".to_string(), "日本語".to_string(), "50".to_string()],
+    ];
+
+    let mut data_to_yank = TableForYank {
+      sql: vec!["select * from t".to_string()],
+      table: TableForYank::to_columns(&headers, &rows),
+    };
+
+    let result = data_to_yank.yank();
+
+    let expected = "\
+select * from t
+
+id | name   | age
+---+--------+-----
+1  | café   | 30
+2  | abcd   | 40
+3  | 日本語 | 50
+";
+
+    assert_eq!(expected, result);
   }
 
   #[test]


### PR DESCRIPTION
"Yank all" pads its aligned table by byte length rather than display width, so
any non-ASCII value produces a crooked table on the clipboard.

```
before:
id | name      | age
---+-----------+-----
1  | café     | 30
2  | abcd      | 40
3  | 日本語 | 50

after:
id | name   | age
---+--------+-----
1  | café   | 30
2  | abcd   | 40
3  | 日本語 | 50
```

`café` is 5 bytes but 4 cells, `日本語` is 9 bytes but 6 cells, so both are
under-padded and the divider is sized off the byte maximum. Accented Latin, CJK
and emoji all hit it, and they are ordinary database contents.

## Cause

`format_column` uses `str::len()`, which is UTF-8 bytes:

```rust
let width = col.iter().map(|s| s.len()).max().unwrap_or(1) + 1;
...
" ".repeat(width.saturating_sub(s.len()))
```

## The fix

Use `UnicodeWidthStr::width` for both the column width and the padding.
`unicode-width` is already a direct dependency, used in
`src/completion/render.rs`, so there is no Cargo.toml change.

## Verification

`yank_aligns_columns_by_display_width` builds a table mixing ASCII, accented
Latin and CJK, and asserts the exact rendered output.

Reverting only the padding line to `s.len()` fails it, and the diff is the
misalignment itself:

```
  left:  "1  | café   | 30\n2  | abcd   | 40\n3  | 日本語 | 50\n"
  right: "1  | café  | 30\n2  | abcd   | 40\n3  | 日本語| 50\n"
```

`cargo test` is 156 passed, 0 failed. `cargo fmt --all --check` is clean and
`cargo clippy --all-targets --all-features --workspace -- -D warnings` reports
nothing.

Two notes on scope:

- This fixes monospace display width. It does not attempt grapheme clustering for
  combining marks or emoji ZWJ sequences, which `unicode-width` measures per
  scalar. That is a deliberately narrower fix than the bug it addresses.
- The existing `yank_is_works` test builds an `expected` string and never asserts
  on it. I left that alone rather than widen this diff, but it is worth a look.

*Disclosure: written with AI assistance (Claude Code). I produced the before and after by calling `TableForYank::yank()` on each tree, and ran the mutation check myself.*
